### PR TITLE
Make the build job on CI parallel

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,14 +6,14 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  GITHUB_PAGES_SUBDIR_APPLICATION: lib/application
+
 jobs:
   build:
-
-    # Settings for GitHub pages deployment, ref: https://github.com/peaceiris/actions-gh-pages#getting-started
-    permissions:
-      contents: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+    strategy:
+      matrix:
+        target: ["application", "playground"]
 
     env:
       python-version: "3.10.2"
@@ -23,7 +23,6 @@ jobs:
       # The Linux VM has 7GB RAM (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources),
       # so we set the max memory size as 6.5 GiB like https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
       NODE_OPTIONS: "--max-old-space-size=6656"
-      GITHUB_PAGES_SUBDIR_APPLICATION: lib/application
 
     runs-on: ubuntu-latest
 
@@ -79,12 +78,15 @@ jobs:
       run: make init
 
     ## Build and deploy the playground app
-    - name: Set PUBLIC_URL
+    - if: matrix.target == 'playground'
+      name: Set PUBLIC_URL
       run: echo "PUBLIC_URL=/${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
-    - name: Build @stlite/playground
+    - if: matrix.target == 'playground'
+      name: Build @stlite/playground
       run: make playground
 
-    - name: Upload the built files as an artifact
+    - if: matrix.target == 'playground'
+      name: Upload the built files as an artifact
       uses: actions/upload-artifact@v2
       with:
         name: stlite-playground
@@ -96,23 +98,55 @@ jobs:
     # because it will load files such as JS chunks and Python wheels at runtime
     # and these dynamic loading will be based on the PUBLIC_URL.
     # If PUBLIC_URL is relative, it will be resolved based on window.location.origin and leads to loading failure.
-    - name: Set PUBLIC_URL
+    - if: matrix.target == 'application'
+      name: Set PUBLIC_URL
       run: echo "PUBLIC_URL=https://${GITHUB_REPOSITORY%/*}.github.io/${GITHUB_REPOSITORY#*/}/${GITHUB_PAGES_SUBDIR_APPLICATION}" >> $GITHUB_ENV
-    - name: Build @stlite/application
+    - if: matrix.target == 'application'
+      name: Build @stlite/application
       run: make application
 
-    - name: Upload the built files as an artifact
+    - if: matrix.target == 'application'
+      name: Upload the built files as an artifact
       uses: actions/upload-artifact@v2
       with:
         name: stlite-application
         path: packages/application/build
 
+  deploy:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    # Settings for GitHub pages deployment, ref: https://github.com/peaceiris/actions-gh-pages#getting-started
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: stlite-playground
+        path: playground
+    - uses: actions/download-artifact@v3
+      with:
+        name: stlite-application
+        path: application
+
+
     - name: Merge the build artifacts
       run: |
         mkdir /tmp/website
-        cp -r ./packages/playground/build/* /tmp/website/.
+        cp -r ./playground/* /tmp/website/.
         mkdir -p /tmp/website/${GITHUB_PAGES_SUBDIR_APPLICATION}
-        cp -r ./packages/application/build/* /tmp/website/${GITHUB_PAGES_SUBDIR_APPLICATION}/.
+        cp -r ./application/* /tmp/website/${GITHUB_PAGES_SUBDIR_APPLICATION}/.
+
+    - name: Upload the website files as an artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ github.ref != 'refs/heads/main' }}
+      with:
+        name: website
+        path: /tmp/website
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
https://github.community/t/reuse-jobs-in-a-workflow-with-parameters/215584/2 says
> In principle you have three options to reuse workflow code:
> 
> * Write one job with a [matrix strategy](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix), putting the parameters into the matrix. This keeps all code in one workflow file.
> * Create a [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) and call it with the appropriate parameters for each environment.
> * Create a [reusable workflow](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) and call it with the appropriate parameters for each environment.

and this PR took the first option, using a matrix strategy.

---

[Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) also looks nice.