### PR TITLE
Create writeFile() and replace mainScriptData with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Here is a sample HTML file.
   <script>
     stlite.mount({
       requirements: ["matplotlib"],  // Packages to install
-      mainScriptData: `
+      entrypoint: "streamlit_app.py",
+      files: {
+        "streamlit_app.py": `
 import streamlit as st
 import matplotlib.pyplot as plt
 import numpy as np
@@ -50,9 +52,10 @@ fig, ax = plt.subplots()
 ax.hist(arr, bins=20)
 
 st.pyplot(fig)
-`,
-      container: document.getElementById("root")
-    })
+`
+      }
+    },
+    document.getElementById("root"))
   </script>
 </body>
 </html>
@@ -60,7 +63,11 @@ st.pyplot(fig)
 
 In this sample,
 * stlite library is imported with the first script tag, then the global `stlite` object becomes available.
-* `stlite.mount()` mounts the Streamlit app to the `<div id="root" />` element as specified via the `container` option and runs the Python script passed through the `mainScriptData` option.
+* `stlite.mount()` mounts and launches the Streamlit app with the `streamlit run` command.
+  * The packages specified at the `requirements` option will be installed at the initialization phase.
+  * The `files` option contains the files to mount on the virtual file system. The object key is a file path and the value is the file content.
+  * The `entrypoint` option is passed to the `streamlit run` command.
+  * The Streamlit app is mounted on the `<div id="root" />` element as specified via the second argument.
 
 > **Warning**
 > stlite is at the very beginning of its development and the API can drastically change without any notice in the future.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,30 @@ Here is a sample HTML file.
   <div id="root"></div>
   <script src="https://whitphx.github.io/stlite/lib/mountable/stlite.js" ></script>
   <script>
+    stlite.mount(`
+import streamlit as st
+
+name = st.text_input('Your name')
+st.write("Hello,", name or "world")
+`,
+    document.getElementById("root"))
+  </script>
+</body>
+</html>
+```
+
+In this sample,
+* stlite library is imported with the first script tag, then the global `stlite` object becomes available.
+* `stlite.mount()` mounts the Streamlit app on the `<div id="root" />` element as specified via the second argument. The app script is passed via the first argument.
+
+### More controls
+
+If more controls are needed such as installing dependencies or mounting multiple files, use the following API instead.
+
+```js
     stlite.mount({
       requirements: ["matplotlib"],  // Packages to install
-      entrypoint: "streamlit_app.py",
+      entrypoint: "streamlit_app.py",  // The target file of the `streamlit run` command
       files: {
         "streamlit_app.py": `
 import streamlit as st
@@ -56,18 +77,7 @@ st.pyplot(fig)
       }
     },
     document.getElementById("root"))
-  </script>
-</body>
-</html>
 ```
-
-In this sample,
-* stlite library is imported with the first script tag, then the global `stlite` object becomes available.
-* `stlite.mount()` mounts and launches the Streamlit app with the `streamlit run` command.
-  * The packages specified at the `requirements` option will be installed at the initialization phase.
-  * The `files` option contains the files to mount on the virtual file system. The object key is a file path and the value is the file content.
-  * The `entrypoint` option is passed to the `streamlit run` command.
-  * The Streamlit app is mounted on the `<div id="root" />` element as specified via the second argument.
 
 > **Warning**
 > stlite is at the very beginning of its development and the API can drastically change without any notice in the future.

--- a/packages/mountable/package.json
+++ b/packages/mountable/package.json
@@ -98,7 +98,7 @@
   "scripts": {
     "start": "node ./scripts/start.js",
     "build": "node ./scripts/build.js",
-    "test": "node ./scripts/testjsh"
+    "test": "node ./scripts/test.js"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/mountable/src/App.test.tsx
+++ b/packages/mountable/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/packages/mountable/src/index.tsx
+++ b/packages/mountable/src/index.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import { StliteKernel } from "@stlite/stlite-kernel";
-import { canonicalizeOptions, MountOptions } from "./options";
+import { canonicalizeMountOptions, MountOptions } from "./options";
 
 export function mount(
   options: MountOptions,
   container: HTMLElement = document.body
 ) {
-  const kernel = new StliteKernel(canonicalizeOptions(options));
+  const kernel = new StliteKernel(canonicalizeMountOptions(options));
 
   ReactDOM.render(
     <React.StrictMode>

--- a/packages/mountable/src/index.tsx
+++ b/packages/mountable/src/index.tsx
@@ -29,7 +29,7 @@ export function mount(
       path: string,
       data: string | ArrayBufferView,
       opts?: Record<string, any>
-    ): Promise<void> => {
+    ) => {
       return kernel.writeFile(path, data, opts);
     },
   };

--- a/packages/mountable/src/index.tsx
+++ b/packages/mountable/src/index.tsx
@@ -1,20 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
-import { StliteKernel, StliteKernelOptions } from "@stlite/stlite-kernel";
+import { StliteKernel } from "@stlite/stlite-kernel";
+import { canonicalizeOptions, MountOptions } from "./options";
 
-export interface MountOptions extends Partial<StliteKernelOptions> {
-  container?: HTMLElement;
-  requirements?: string[];
-}
-
-export function mount(options?: MountOptions) {
-  const container = options?.container || document.body;
-
-  const kernel = new StliteKernel({
-    command: options?.command || (options?.mainScriptData ? "run" : "hello"),
-    ...options,
-  });
+export function mount(
+  options: MountOptions,
+  container: HTMLElement = document.body
+) {
+  const kernel = new StliteKernel(canonicalizeOptions(options));
 
   ReactDOM.render(
     <React.StrictMode>
@@ -28,39 +22,43 @@ export function mount(options?: MountOptions) {
       kernel.dispose();
       ReactDOM.unmountComponentAtNode(container);
     },
-    setMainScriptData: (mainScriptData: string) => {
-      kernel.setMainScriptData(mainScriptData);
+    install: (requirements: string[]) => {
+      return kernel.install(requirements);
+    },
+    writeFile: (
+      path: string,
+      data: string | ArrayBufferView,
+      opts?: Record<string, any>
+    ): Promise<void> => {
+      return kernel.writeFile(path, data, opts);
     },
   };
 }
 
 if (process.env.NODE_ENV === "development") {
-  mount({
-    requirements: ["opencv-python"],
-    command: "run",
-    mainScriptData: `import streamlit as st
-import pandas as pd
+  mount(
+    //     `import streamlit as st
+
+    // st.write("Hello world")
+    //     `,
+    {
+      entrypoint: "streamlit_app.py",
+      files: {
+        "streamlit_app.py": `import streamlit as st
+import matplotlib.pyplot as plt
 import numpy as np
-import cv2
 
-st.write("Hello world")
+size = st.slider("Sample size", 100, 1000)
 
-chart_data = pd.DataFrame(
-    np.random.randn(20, 3),
-    columns=['a', 'b', 'c'])
-st.write(chart_data)
-st.line_chart(chart_data)
+arr = np.random.normal(1, 1, size=size)
+fig, ax = plt.subplots()
+ax.hist(arr, bins=20)
 
-img_file_buffer = st.camera_input("Take a picture")
-
-if img_file_buffer is not None:
-    bytes_data = img_file_buffer.getvalue()
-    cv2_img = cv2.imdecode(np.frombuffer(bytes_data, np.uint8), cv2.IMREAD_COLOR)
-
-    cv2_img = cv2.Canny(cv2_img, 100, 200)
-
-    st.image(cv2_img)
-`,
-    container: document.getElementById("root") as HTMLElement,
-  });
+st.pyplot(fig)
+    `,
+      },
+      requirements: ["matplotlib"],
+    },
+    document.getElementById("root") as HTMLElement
+  );
 }

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -45,4 +45,15 @@ describe("canonicalizeOptions()", () => {
       }
     })
   });
+
+  it(`sets \`command="hello"\` if .hello=true`, () => {
+
+    expect(canonicalizeOptions({
+      hello: true,
+    })).toEqual({
+      command: "hello",
+      entrypoint: "streamlit_app.py",
+      files: {}
+    })
+  })
 })

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -1,0 +1,48 @@
+import { canonicalizeOptions } from "./options"
+
+describe("canonicalizeOptions()", () => {
+  it("translates a string input into StliteKernelOption", () => {
+    expect(canonicalizeOptions("foo")).toEqual({
+      command: "run",
+      entrypoint: "streamlit_app.py",
+      files: {
+        "streamlit_app.py": {
+          data: "foo"
+        }
+      }
+    })
+  })
+
+  it("fills `entrypoint` and `command` fields and converts the `files` into the canonical form", () => {
+    expect(canonicalizeOptions({
+      files: {
+        "streamlit_app.py": "foo"
+      }
+    })).toEqual({
+      command: "run",
+      entrypoint: "streamlit_app.py",
+      files: {
+        "streamlit_app.py": {
+          data: "foo"
+        }
+      }
+    })
+  })
+
+  it("preserves the `entrypoint` field if specified", () => {
+    expect(canonicalizeOptions({
+      entrypoint: "foo.py",
+      files: {
+        "streamlit_app.py": "foo"
+      }
+    })).toEqual({
+      command: "run",
+      entrypoint: "foo.py",
+      files: {
+        "streamlit_app.py": {
+          data: "foo"
+        }
+      }
+    })
+  });
+})

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -45,4 +45,15 @@ describe("canonicalizeOptions()", () => {
       }
     })
   });
+
+  it("preserves the `requirements` option if specified", () => {
+    expect(canonicalizeOptions({
+      requirements: ["matplotlib"]
+    })).toEqual({
+      command: "run",
+      requirements: ["matplotlib"],
+      entrypoint: "streamlit_app.py",
+      files: {}
+    })
+  })
 })

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -45,15 +45,4 @@ describe("canonicalizeOptions()", () => {
       }
     })
   });
-
-  it(`sets \`command="hello"\` if .hello=true`, () => {
-
-    expect(canonicalizeOptions({
-      hello: true,
-    })).toEqual({
-      command: "hello",
-      entrypoint: "streamlit_app.py",
-      files: {}
-    })
-  })
 })

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -1,8 +1,8 @@
-import { canonicalizeOptions } from "./options"
+import { canonicalizeMountOptions } from "./options"
 
-describe("canonicalizeOptions()", () => {
+describe("canonicalizeMountOptions()", () => {
   it("translates a string input into StliteKernelOptions", () => {
-    expect(canonicalizeOptions("foo")).toEqual({
+    expect(canonicalizeMountOptions("foo")).toEqual({
       command: "run",
       entrypoint: "streamlit_app.py",
       files: {
@@ -15,7 +15,7 @@ describe("canonicalizeOptions()", () => {
   })
 
   it("fills `command`, `entrypoint`, and `requirements` fields and converts the `files` into the canonical form", () => {
-    expect(canonicalizeOptions({
+    expect(canonicalizeMountOptions({
       files: {
         "streamlit_app.py": "foo"
       }
@@ -32,7 +32,7 @@ describe("canonicalizeOptions()", () => {
   })
 
   it("preserves the `entrypoint` field if specified", () => {
-    expect(canonicalizeOptions({
+    expect(canonicalizeMountOptions({
       entrypoint: "foo.py",
       files: {
         "streamlit_app.py": "foo"
@@ -50,7 +50,7 @@ describe("canonicalizeOptions()", () => {
   });
 
   it("preserves the `requirements` option if specified", () => {
-    expect(canonicalizeOptions({
+    expect(canonicalizeMountOptions({
       requirements: ["matplotlib"]
     })).toEqual({
       command: "run",

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -9,7 +9,8 @@ describe("canonicalizeOptions()", () => {
         "streamlit_app.py": {
           data: "foo"
         }
-      }
+      },
+      requirements: [],
     })
   })
 
@@ -25,7 +26,8 @@ describe("canonicalizeOptions()", () => {
         "streamlit_app.py": {
           data: "foo"
         }
-      }
+      },
+      requirements: [],
     })
   })
 
@@ -42,7 +44,8 @@ describe("canonicalizeOptions()", () => {
         "streamlit_app.py": {
           data: "foo"
         }
-      }
+      },
+      requirements: [],
     })
   });
 

--- a/packages/mountable/src/options.test.ts
+++ b/packages/mountable/src/options.test.ts
@@ -1,7 +1,7 @@
 import { canonicalizeOptions } from "./options"
 
 describe("canonicalizeOptions()", () => {
-  it("translates a string input into StliteKernelOption", () => {
+  it("translates a string input into StliteKernelOptions", () => {
     expect(canonicalizeOptions("foo")).toEqual({
       command: "run",
       entrypoint: "streamlit_app.py",
@@ -14,7 +14,7 @@ describe("canonicalizeOptions()", () => {
     })
   })
 
-  it("fills `entrypoint` and `command` fields and converts the `files` into the canonical form", () => {
+  it("fills `command`, `entrypoint`, and `requirements` fields and converts the `files` into the canonical form", () => {
     expect(canonicalizeOptions({
       files: {
         "streamlit_app.py": "foo"
@@ -22,12 +22,12 @@ describe("canonicalizeOptions()", () => {
     })).toEqual({
       command: "run",
       entrypoint: "streamlit_app.py",
+      requirements: [],
       files: {
         "streamlit_app.py": {
           data: "foo"
         }
       },
-      requirements: [],
     })
   })
 
@@ -40,12 +40,12 @@ describe("canonicalizeOptions()", () => {
     })).toEqual({
       command: "run",
       entrypoint: "foo.py",
+      requirements: [],
       files: {
         "streamlit_app.py": {
           data: "foo"
         }
       },
-      requirements: [],
     })
   });
 

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -32,7 +32,7 @@ const DEFAULT_ENTRYPOINT = "streamlit_app.py";
 
 export type MountOptions = string | SimplifiedStliteKernelOptions;
 
-export function canonicalizeOptions(options: string | SimplifiedStliteKernelOptions): StliteKernelOptions {
+export function canonicalizeMountOptions(options: string | SimplifiedStliteKernelOptions): StliteKernelOptions {
   if (typeof options === "string") {
     const mainScript = options;
     return {

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -36,12 +36,11 @@ export type MountOptions = string | SimplifiedStliteKernelOptions;
 export function canonicalizeOptions(options: string | SimplifiedStliteKernelOptions): StliteKernelOptions {
   if (typeof options === "string") {
     const mainScript = options;
-    const entrypoint = "streamlit_app.py";
     return {
       command: "run",
-      entrypoint,
+      entrypoint: DEFAULT_ENTRYPOINT,
       files: {
-        [entrypoint]: {
+        [DEFAULT_ENTRYPOINT]: {
           data: mainScript,
         },
       },

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -1,8 +1,7 @@
 import { StliteKernelOptions } from "@stlite/stlite-kernel";
 
 type SimplifiedFiles = Record<string, string | ArrayBufferView>;
-export interface SimplifiedStliteKernelOptions
-  extends Omit<StliteKernelOptions, "command" | "entrypoint" | "files"> {
+export interface SimplifiedStliteKernelOptions {
   entrypoint?: string;
   requirements?: StliteKernelOptions["requirements"];
   files?: StliteKernelOptions["files"] | SimplifiedFiles;
@@ -44,15 +43,16 @@ export function canonicalizeOptions(options: string | SimplifiedStliteKernelOpti
           data: mainScript,
         },
       },
+      requirements: [],
     }
   }
 
   const files = canonicalizeFiles(options.files);
 
   return {
-    ...options,
     command: "run",
     entrypoint: options.entrypoint || DEFAULT_ENTRYPOINT,
     files,
+    requirements: options.requirements || [],
   };
 }

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -1,0 +1,60 @@
+import { StliteKernelOptions } from "@stlite/stlite-kernel";
+
+type SimplifiedFiles = Record<string, string | ArrayBufferView>;
+export interface SimplifiedStliteKernelOptions
+  extends Omit<StliteKernelOptions, "command" | "entrypoint" | "files"> {
+  entrypoint?: string;
+  requirements?: StliteKernelOptions["requirements"];
+  files?: StliteKernelOptions["files"] | SimplifiedFiles;
+  hello?: boolean;
+}
+
+function canonicalizeFiles(
+  files: SimplifiedStliteKernelOptions["files"]
+): NonNullable<StliteKernelOptions["files"]> {
+  if (files == null) {
+    return {};
+  }
+
+  const canonicalFiles: StliteKernelOptions["files"] = {};
+  Object.keys(files).forEach((key) => {
+    const value = files[key];
+    if (typeof value === "object" && "data" in value) {
+      canonicalFiles[key] = value;
+    } else {
+      canonicalFiles[key] = {
+        data: value,
+      };
+    }
+  });
+  return canonicalFiles;
+}
+
+const DEFAULT_ENTRYPOINT = "streamlit_app.py";
+
+export type MountOptions = string | SimplifiedStliteKernelOptions;
+
+export function canonicalizeOptions(options: string | SimplifiedStliteKernelOptions): StliteKernelOptions {
+  if (typeof options === "string") {
+    const mainScript = options;
+    const entrypoint = "streamlit_app.py";
+    return {
+      command: "run",
+      entrypoint,
+      files: {
+        [entrypoint]: {
+          data: mainScript,
+        },
+      },
+    }
+  }
+
+  const files = canonicalizeFiles(options.files);
+
+  return {
+    ...options,
+    command: options.hello ? "hello" : "run",
+    entrypoint: options.entrypoint || DEFAULT_ENTRYPOINT,
+    files,
+  };
+}

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -6,7 +6,6 @@ export interface SimplifiedStliteKernelOptions
   entrypoint?: string;
   requirements?: StliteKernelOptions["requirements"];
   files?: StliteKernelOptions["files"] | SimplifiedFiles;
-  hello?: boolean;
 }
 
 function canonicalizeFiles(
@@ -52,7 +51,7 @@ export function canonicalizeOptions(options: string | SimplifiedStliteKernelOpti
   const files = canonicalizeFiles(options.files);
 
   return {
-    command: options.hello ? "hello" : "run",
+    command: "run",
     entrypoint: options.entrypoint || DEFAULT_ENTRYPOINT,
     files,
   };

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -52,7 +52,6 @@ export function canonicalizeOptions(options: string | SimplifiedStliteKernelOpti
   const files = canonicalizeFiles(options.files);
 
   return {
-    ...options,
     command: options.hello ? "hello" : "run",
     entrypoint: options.entrypoint || DEFAULT_ENTRYPOINT,
     files,

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -50,6 +50,7 @@ export function canonicalizeOptions(options: string | SimplifiedStliteKernelOpti
   const files = canonicalizeFiles(options.files);
 
   return {
+    ...options,
     command: "run",
     entrypoint: options.entrypoint || DEFAULT_ENTRYPOINT,
     files,

--- a/packages/mountable/src/setupTests.ts
+++ b/packages/mountable/src/setupTests.ts
@@ -1,5 +1,5 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+// // jest-dom adds custom jest matchers for asserting on DOM nodes.
+// // allows you to do things like:
+// // expect(element).toHaveTextContent(/react/i)
+// // learn more: https://github.com/testing-library/jest-dom
+// import '@testing-library/jest-dom';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -54,6 +54,7 @@ function App() {
   useEffect(() => {
     const kernel = new StliteKernel({
       command: "run",
+      entrypoint: ENTRYPOINT,
       requirements: DEFAULT_REQUIREMENTS,
       files: {
         [ENTRYPOINT]: {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -45,6 +45,8 @@ st.markdown("hiplot returned " + json.dumps(ret_val))
 
 const DEFAULT_REQUIREMENTS = ["matplotlib", "hiplot"];
 
+const ENTRYPOINT = "streamlit_app.py";
+
 function App() {
   const [mainScriptData, setMainScriptData] = useState(DEFAULT_VALUE);
 
@@ -53,7 +55,11 @@ function App() {
     const kernel = new StliteKernel({
       command: "run",
       requirements: DEFAULT_REQUIREMENTS,
-      mainScriptData,
+      files: {
+        [ENTRYPOINT]: {
+          data: mainScriptData,
+        },
+      },
     });
     setKernel(kernel);
 
@@ -68,7 +74,7 @@ function App() {
       return;
     }
 
-    kernel.setMainScriptData(mainScriptData);
+    kernel.writeFile(ENTRYPOINT, mainScriptData);
   }, [kernel, mainScriptData]);
 
   return (

--- a/packages/stlite-kernel/src/kernel.ts
+++ b/packages/stlite-kernel/src/kernel.ts
@@ -49,7 +49,10 @@ export interface StliteKernelOptions {
   /**
    * Files to mount.
    */
-  files?: Record<string, { data: string | ArrayBufferView, opts?: Record<string, any> }>;
+  files?: Record<
+    string,
+    { data: string | ArrayBufferView; opts?: Record<string, any> }
+  >;
 }
 
 export class StliteKernel {

--- a/packages/stlite-kernel/src/kernel.ts
+++ b/packages/stlite-kernel/src/kernel.ts
@@ -44,12 +44,12 @@ export interface StliteKernelOptions {
   /**
    * A list of package names to be install at the booting-up phase.
    */
-  requirements?: string[];
+  requirements: string[];
 
   /**
    * Files to mount.
    */
-  files?: Record<
+  files: Record<
     string,
     { data: string | ArrayBufferView; opts?: Record<string, any> }
   >;
@@ -87,8 +87,8 @@ export class StliteKernel {
     this._workerInitData = {
       command: options.command,
       entrypoint: options.entrypoint,
-      files: options.files || {},
-      requirements: options.requirements || [],
+      files: options.files,
+      requirements: options.requirements,
       wheels: {
         tornado: tornadoWheelUrl,
         pyarrow: pyarrowWheelUrl,

--- a/packages/stlite-kernel/src/types.d.ts
+++ b/packages/stlite-kernel/src/types.d.ts
@@ -62,6 +62,14 @@ interface MainScriptSetMessage extends InMessageBase {
     mainScriptData: string;
   };
 }
+interface WriteFileMessage extends InMessageBase {
+  type: "file:write";
+  data: {
+    path: string;
+    data: string | ArrayBufferView;
+    opts?: Record<string, any>;
+  };
+}
 interface InstallMessage extends InMessageBase {
   type: "install";
   data: {
@@ -74,6 +82,7 @@ type InMessage =
   | WebSocketSendMessage
   | HttpRequestMessage
   | MainScriptSetMessage
+  | WriteFileMessage
   | InstallMessage;
 
 interface StliteWorker extends Worker {

--- a/packages/stlite-kernel/src/types.d.ts
+++ b/packages/stlite-kernel/src/types.d.ts
@@ -14,16 +14,15 @@ interface EmscriptenFile {
   opts?: Record<string, string>;
 }
 interface WorkerInitialData {
-  requirements: string[];
-  mainScriptData?: string;
-  mainScriptPath: string;
   command: "run" | "hello";
+  entrypoint: string;
+  files: Record<string, EmscriptenFile>;
+  requirements: string[];
   wheels: {
     tornado: string;
     pyarrow: string;
     streamlit: string;
   };
-  files: Record<string, EmscriptenFile>;
 }
 
 /**
@@ -56,12 +55,6 @@ interface HttpRequestMessage extends InMessageBase {
     request: HttpRequest;
   };
 }
-interface MainScriptSetMessage extends InMessageBase {
-  type: "mainscript:set";
-  data: {
-    mainScriptData: string;
-  };
-}
 interface WriteFileMessage extends InMessageBase {
   type: "file:write";
   data: {
@@ -81,7 +74,6 @@ type InMessage =
   | WebSocketConnectMessage
   | WebSocketSendMessage
   | HttpRequestMessage
-  | MainScriptSetMessage
   | WriteFileMessage
   | InstallMessage;
 

--- a/packages/stlite-kernel/src/worker.ts
+++ b/packages/stlite-kernel/src/worker.ts
@@ -38,7 +38,7 @@ async function loadPyodideAndPackages() {
   const {
     requirements,
     command,
-    mainScriptData,
+    mainScriptData = "",
     mainScriptPath,
     wheels,
     files,
@@ -346,6 +346,24 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
       pyodide.FS.writeFile(_mainScriptPath, mainScriptData, {
         encoding: "utf8",
       });
+      break;
+    }
+    case "file:write": {
+      const messagePort = event.ports[0];
+      const { path, data: fileData, opts } = data.data;
+
+      try {
+        console.debug(`Write a file "${path}"`);
+        writeFileWithParents(pyodide, path, fileData, opts);
+        messagePort.postMessage({
+          type: "reply",
+        });
+      } catch (error) {
+        messagePort.postMessage({
+          type: "reply",
+          error,
+        });
+      }
       break;
     }
     case "install": {

--- a/packages/stlite-kernel/src/worker.ts
+++ b/packages/stlite-kernel/src/worker.ts
@@ -4,8 +4,6 @@ importScripts("https://cdn.jsdelivr.net/pyodide/v0.21.0/full/pyodide.js");
 
 let pyodide: any;
 
-let _mainScriptPath: string;
-
 let httpServer: any;
 
 interface StliteWorkerContext extends Worker {
@@ -35,16 +33,8 @@ const initDataPromise = new Promise<WorkerInitialData>((resolve) => {
  *       https://github.com/jupyterlite/jupyterlite/pull/310
  */
 async function loadPyodideAndPackages() {
-  const {
-    requirements,
-    command,
-    mainScriptData = "",
-    mainScriptPath,
-    wheels,
-    files,
-  } = await initDataPromise;
-
-  _mainScriptPath = mainScriptPath;
+  const { command, entrypoint, files, requirements, wheels } =
+    await initDataPromise;
 
   // as of 0.17.0 indexURL must be provided
   pyodide = await loadPyodide({
@@ -227,11 +217,7 @@ async function loadPyodideAndPackages() {
   if (command === "hello") {
     await pyodide.runPythonAsync(`main_hello(**command_kwargs)`);
   } else if (command === "run") {
-    pyodide.FS.writeFile(mainScriptPath, mainScriptData, { encoding: "utf8" });
-
-    await pyodide.runPythonAsync(
-      `main_run("${mainScriptPath}", **command_kwargs)`
-    );
+    await pyodide.runPythonAsync(`main_run("${entrypoint}", **command_kwargs)`);
   }
 
   // Pull the http server instance from Python world to JS world and set up it.
@@ -339,13 +325,6 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
         request.body,
         onResponse
       );
-      break;
-    }
-    case "mainscript:set": {
-      const { mainScriptData } = data.data;
-      pyodide.FS.writeFile(_mainScriptPath, mainScriptData, {
-        encoding: "utf8",
-      });
       break;
     }
     case "file:write": {

--- a/packages/toy-app/src/App.tsx
+++ b/packages/toy-app/src/App.tsx
@@ -21,6 +21,7 @@ st.write("Hello World")
 `,
         },
       },
+      requirements: [],
     });
 
     kernel

--- a/packages/toy-app/src/App.tsx
+++ b/packages/toy-app/src/App.tsx
@@ -12,6 +12,15 @@ function App() {
   useEffect(() => {
     const kernel = new StliteKernel({
       command: "run",
+      entrypoint: "streamlit_app.py",
+      files: {
+        "streamlit_app.py": {
+          data: `import streamlit as st
+
+st.write("Hello World")
+`,
+        },
+      },
     });
 
     kernel
@@ -44,10 +53,13 @@ function App() {
 
           setTimeout(() => {
             console.log("Set a new script");
-            kernel.setMainScriptData(`import streamlit as st
+            kernel.writeFile(
+              "streamlit_app.py",
+              `import streamlit as st
 
 st.write("Hello, a new script")
-`);
+`
+            );
           }, 1000);
         }
       },


### PR DESCRIPTION
- Create StliteKernel.writeFile and fix the playground app to use it
- Remove mainScriptPath and mainScriptData options from stlite-kernel
- Fix @stlite/mountable and @stlite/playground to use the new API of stlite-kernel
