### PR TITLE
Update to resolve paths when the script is loaded from non-root paths

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -88,14 +88,10 @@ jobs:
         path: packages/playground/build
 
     ## Build and deploy @stlite/mountable
-    # Set PUBLIC_URL for the mountable package, which will be deployed to the sub directory ${GITHUB_PAGES_SUBDIR_MOUNTABLE}.
-    # An absolute URL must be set to PUBLIC_URL when the bundled file will be imported from other origins
-    # because it will load files such as JS chunks and Python wheels at runtime
-    # and these dynamic loading will be based on the PUBLIC_URL.
-    # If PUBLIC_URL is relative, it will be resolved based on window.location.origin and leads to loading failure.
+    # PUBLIC_URL here is set as a relative path, which is possible to the trick introduced at https://github.com/whitphx/stlite/pull/143.
     - if: matrix.target == 'mountable'
       name: Set PUBLIC_URL
-      run: echo "PUBLIC_URL=https://${GITHUB_REPOSITORY%/*}.github.io/${GITHUB_REPOSITORY#*/}/${GITHUB_PAGES_SUBDIR_MOUNTABLE}" >> $GITHUB_ENV
+      run: echo "PUBLIC_URL=." >> $GITHUB_ENV
     - if: matrix.target == 'mountable'
       name: Build @stlite/mountable
       run: make mountable

--- a/packages/mountable/src/index.tsx
+++ b/packages/mountable/src/index.tsx
@@ -15,11 +15,13 @@ if (
   typeof __webpack_public_path__ === "string" &&
   (__webpack_public_path__ === "." || __webpack_public_path__.startsWith("./"))
 ) {
-  const selfScriptUrl = (document.currentScript as HTMLScriptElement).src;
-  const selfScriptBaseUrl = getParentUrl(selfScriptUrl);
+  if (document.currentScript && "src" in document.currentScript) {
+    const selfScriptUrl = document.currentScript.src;
+    const selfScriptBaseUrl = getParentUrl(selfScriptUrl);
 
-  __webpack_public_path__ = selfScriptBaseUrl; // For webpack dynamic imports
-  wheelBaseUrl = selfScriptBaseUrl;
+    __webpack_public_path__ = selfScriptBaseUrl; // For webpack dynamic imports
+    wheelBaseUrl = selfScriptBaseUrl;
+  }
 }
 
 export function mount(

--- a/packages/mountable/src/index.tsx
+++ b/packages/mountable/src/index.tsx
@@ -6,9 +6,9 @@ import { getParentUrl } from "./url";
 import { canonicalizeMountOptions, MountOptions } from "./options";
 
 /**
- * If PUBLIC_PATH which is exported as a global variable `__webpack_public_path__` (https://webpack.js.org/guides/public-path/#on-the-fly)
- * is set as a relative URL, resolve it based on the URL of this script itself,
- * which will transpiled into `stlite.js` at the root of the output directory.
+ * If `PUBLIC_PATH` which is exported as a global variable `__webpack_public_path__` (https://webpack.js.org/guides/public-path/#on-the-fly)
+ * is set as a relative URL, resolve and override it based on the URL of this script itself,
+ * which will be transpiled into `stlite.js` at the root of the output directory.
  */
 let wheelBaseUrl: string | undefined = undefined;
 if (

--- a/packages/mountable/src/index.tsx
+++ b/packages/mountable/src/index.tsx
@@ -2,13 +2,34 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import { StliteKernel } from "@stlite/stlite-kernel";
+import { getParentUrl } from "./url";
 import { canonicalizeMountOptions, MountOptions } from "./options";
+
+/**
+ * If PUBLIC_PATH which is exported as a global variable `__webpack_public_path__` (https://webpack.js.org/guides/public-path/#on-the-fly)
+ * is set as a relative URL, resolve it based on the URL of this script itself,
+ * which will transpiled into `stlite.js` at the root of the output directory.
+ */
+let wheelBaseUrl: string | undefined = undefined;
+if (
+  typeof __webpack_public_path__ === "string" &&
+  (__webpack_public_path__ === "." || __webpack_public_path__.startsWith("./"))
+) {
+  const selfScriptUrl = (document.currentScript as HTMLScriptElement).src;
+  const selfScriptBaseUrl = getParentUrl(selfScriptUrl);
+
+  __webpack_public_path__ = selfScriptBaseUrl; // For webpack dynamic imports
+  wheelBaseUrl = selfScriptBaseUrl;
+}
 
 export function mount(
   options: MountOptions,
   container: HTMLElement = document.body
 ) {
-  const kernel = new StliteKernel(canonicalizeMountOptions(options));
+  const kernel = new StliteKernel({
+    ...canonicalizeMountOptions(options),
+    wheelBaseUrl,
+  });
 
   ReactDOM.render(
     <React.StrictMode>

--- a/packages/mountable/src/types.d.ts
+++ b/packages/mountable/src/types.d.ts
@@ -1,2 +1,2 @@
 
-declare let __webpack_public_path__: string | undefined;
+declare let __webpack_public_path__: string | undefined;  // Ref: https://webpack.js.org/guides/public-path/#on-the-fly

--- a/packages/mountable/src/types.d.ts
+++ b/packages/mountable/src/types.d.ts
@@ -1,0 +1,2 @@
+
+declare let __webpack_public_path__: string | undefined;

--- a/packages/mountable/src/url.test.ts
+++ b/packages/mountable/src/url.test.ts
@@ -1,0 +1,15 @@
+import { getParentUrl } from "./url"
+
+describe("getParentUrl()", () => {
+  const testCases: { input: string; expected: string }[] = [
+    {
+      input: "https://whitphx.github.io/stlite/lib/mountable/stlite.js",
+      expected: "https://whitphx.github.io/stlite/lib/mountable/"
+    }
+  ]
+  testCases.forEach(({ input, expected }) => {
+    it(`extracts "${expected}" from "${input}"`, () => {
+      expect(getParentUrl(input)).toEqual(expected)
+    })
+  })
+});

--- a/packages/mountable/src/url.test.ts
+++ b/packages/mountable/src/url.test.ts
@@ -1,11 +1,34 @@
 import { getParentUrl } from "./url"
 
 describe("getParentUrl()", () => {
+  beforeEach(() => {
+    const originalLocation = window.location;
+    jest.spyOn(window, "location", "get").mockImplementation(() => ({
+      ...originalLocation,
+      origin: "https://example.com:3000"
+    }))
+  });
+  afterEach(() => {
+    jest.restoreAllMocks()
+  });
+
   const testCases: { input: string; expected: string }[] = [
+    {
+      input: "https://whitphx.github.io/stlite.js",
+      expected: "https://whitphx.github.io/"
+    },
     {
       input: "https://whitphx.github.io/stlite/lib/mountable/stlite.js",
       expected: "https://whitphx.github.io/stlite/lib/mountable/"
-    }
+    },
+    {
+      input: "./stlite.js",
+      expected: "https://example.com:3000/"
+    },
+    {
+      input: "./stlite/lib/mountable/stlite.js",
+      expected: "https://example.com:3000/stlite/lib/mountable/"
+    },
   ]
   testCases.forEach(({ input, expected }) => {
     it(`extracts "${expected}" from "${input}"`, () => {

--- a/packages/mountable/src/url.test.ts
+++ b/packages/mountable/src/url.test.ts
@@ -22,13 +22,20 @@ describe("getParentUrl()", () => {
       expected: "https://whitphx.github.io/stlite/lib/mountable/"
     },
     {
+      // A relative URL is resolved based on window.location.origin.
       input: "./stlite.js",
       expected: "https://example.com:3000/"
     },
     {
+      // A relative URL is resolved based on window.location.origin.
       input: "./stlite/lib/mountable/stlite.js",
       expected: "https://example.com:3000/stlite/lib/mountable/"
     },
+    {
+      // An empty URL is treated as "./"
+      input: "",
+      expected: "https://example.com:3000/"
+    }
   ]
   testCases.forEach(({ input, expected }) => {
     it(`extracts "${expected}" from "${input}"`, () => {

--- a/packages/mountable/src/url.ts
+++ b/packages/mountable/src/url.ts
@@ -1,12 +1,3 @@
-function isAbsoluteURL(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false
-  }
-}
-
 export function getParentUrl(url: string): string {
   const parentURL = url.split("/").slice(0, -1).join("/") + "/";
 

--- a/packages/mountable/src/url.ts
+++ b/packages/mountable/src/url.ts
@@ -1,0 +1,3 @@
+export function getParentUrl(url: string): string {
+  return url.split("/").slice(0, -1).join("/") + "/"
+}

--- a/packages/mountable/src/url.ts
+++ b/packages/mountable/src/url.ts
@@ -1,3 +1,18 @@
+function isAbsoluteURL(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false
+  }
+}
+
 export function getParentUrl(url: string): string {
-  return url.split("/").slice(0, -1).join("/") + "/"
+  const parentURL = url.split("/").slice(0, -1).join("/") + "/";
+
+  try {
+    return new URL(parentURL).toString();  // If `parentURL` is an absolute URL, this passes.
+  } catch {
+    return new URL(parentURL, window.location.origin).toString();
+  }
 }

--- a/packages/stlite-kernel/src/url.test.ts
+++ b/packages/stlite-kernel/src/url.test.ts
@@ -3,7 +3,11 @@ import { makeAbsoluteWheelURL } from "./url";
 
 describe("makeAbsoluteWheelURL", () => {
   beforeEach(() => {
-    vi.stubGlobal("window.location.origin", "https://localhost:3000");
+    const originalLocation = window.location;
+    vi.spyOn(window, "location", "get").mockImplementation(() => ({
+      ...originalLocation,
+      origin: "https://example.com:3000",
+    }));
   });
   afterEach(() => {
     vi.resetAllMocks();
@@ -15,7 +19,7 @@ describe("makeAbsoluteWheelURL", () => {
         // Absolute path is resolved based on window.location.origin
         wheelUrl: "/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
         expected:
-          "http://localhost:3000/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+          "https://example.com:3000/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
       },
       {
         // Absolute path with baseURL is resolved based on the baseURL's origin.
@@ -34,9 +38,9 @@ describe("makeAbsoluteWheelURL", () => {
       {
         // Relative path is resolved based on the baseURL.
         wheelUrl: "./pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
-        baseUrl: "http://localhost:3000/build/",
+        baseUrl: "http://example.com:3000/build/",
         expected:
-          "http://localhost:3000/build/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+          "http://example.com:3000/build/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
       },
     ];
   testCases.forEach(({ wheelUrl, baseUrl, expected }) => {

--- a/packages/stlite-kernel/src/url.test.ts
+++ b/packages/stlite-kernel/src/url.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { makeAbsoluteWheelURL } from "./url";
+
+describe("makeAbsoluteWheelURL", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window.location.origin", "https://localhost:3000");
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const testCases: { wheelUrl: string; baseUrl?: string; expected: string }[] =
+    [
+      {
+        // Absolute path is resolved based on window.location.origin
+        wheelUrl: "/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+        expected:
+          "http://localhost:3000/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+      },
+      {
+        // Absolute path with baseURL is resolved based on the baseURL's origin.
+        wheelUrl: "/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+        baseUrl: "https://whitphx.github.io/stlite",
+        expected:
+          "https://whitphx.github.io/whitphx/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+      },
+      {
+        // Absolute URL is returned as-is.
+        wheelUrl:
+          "https://whitphx.github.io/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+        expected:
+          "https://whitphx.github.io/stlite/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+      },
+      {
+        // Relative path is resolved based on the baseURL.
+        wheelUrl: "./pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+        baseUrl: "http://localhost:3000/build/",
+        expected:
+          "http://localhost:3000/build/pypi/stlite_pyarrow-0.1.0-py3-none-any.whl",
+      },
+    ];
+  testCases.forEach(({ wheelUrl, baseUrl, expected }) => {
+    it(`resolves the wheel URL (${wheelUrl}) as an absolute URL (${expected}) with a hint of baseUrl (${baseUrl})`, () => {
+      expect(makeAbsoluteWheelURL(wheelUrl, baseUrl)).toEqual(expected);
+    });
+  });
+});

--- a/packages/stlite-kernel/src/url.ts
+++ b/packages/stlite-kernel/src/url.ts
@@ -1,0 +1,27 @@
+import { URLExt } from "@jupyterlab/coreutils";
+
+function isAbsoluteURL(url: string): boolean {
+  try {
+    new URL(url); // Fails if `url` is relative and the second argument `base` is not given.
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function makeAbsoluteWheelURL(url: string, baseUrl?: string): string {
+  if (isAbsoluteURL(url)) {
+    return url;
+  }
+
+  if (url.startsWith("./")) {
+    if (baseUrl == null) {
+      throw new Error(`baseUrl is null`);
+    }
+    return URLExt.join(baseUrl, url);
+  }
+
+  const baseOrigin = baseUrl ? new URL(baseUrl).origin : window.location.origin;
+
+  return URLExt.join(baseOrigin, url);
+}


### PR DESCRIPTION
Until now, if the `stlite.js` is transpiled without a proper `PUBLIC_URL` setting or it is hosted at the URL different from `PUBLIC_URL`, the execution have failed because it could not load the wheel files for the stlite kernel and the JS chunks for the React app as the resolved URLs of these resources were pointing to the wrong locations.
With this change, those URLs will be resolved based on the parent URL of the `stlite.js`, assuming that the `stlite.js` is located at the root directory of the build artifact and the URLs of the wheels and the JS chunks represent the relative paths to the URL of the root directory.

This trick is necessary, for example, to host this package from CDN which assigns URLs to the package that are not controllable from our side and not stable.