### PR TITLE
Rename main.css to stlite.css

### DIFF
--- a/packages/mountable/config/webpack.config.js
+++ b/packages/mountable/config/webpack.config.js
@@ -635,7 +635,7 @@ module.exports = function (webpackEnv) {
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional
-          filename: 'main.css',
+          filename: 'stlite.css',
           chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
         }),
       // Generate an asset manifest file with the following content:


### PR DESCRIPTION
Because the former one is less descriptive especially when, for example, used without being loaded from a CDN, where the string "stlite" is not included in the resource URL at all.
