### PR TITLE
Change the URL hash encoding method simply using base64 (base64url) and remove LZString for efficiency

### DIFF
--- a/packages/sharing-common/package.json
+++ b/packages/sharing-common/package.json
@@ -16,11 +16,9 @@
     "check:prettier": "prettier --check ."
   },
   "dependencies": {
-    "lz-string": "^1.4.4",
     "protobufjs": "^7.1.0"
   },
   "devDependencies": {
-    "@types/lz-string": "^1.3.34",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "eslint": "^8.21.0",

--- a/packages/sharing-common/src/buffer.test.ts
+++ b/packages/sharing-common/src/buffer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { ab2str, str2ab } from "./buffer";
+import { abTobase64, base64ToAb } from "./buffer";
 
 function createDummyArrayBuffer(byteLength: number): ArrayBuffer {
   const arrayBuffer = new ArrayBuffer(byteLength);
@@ -31,19 +31,14 @@ test("vitest matcher for ArrayBuffer", () => {
 [
   1,
   2,
-  3, // Not a multiple of 2: A special care is needed for Uint16Array.
+  3,
   4,
-  5, // A number exceeding a minimum byteLength of Uint32Array is also tested tentatively.
-  0xffff - 1, // The last byte would be filled with 1 at almost every bit (0b1111111111111110)
-  0xffff - 2,
-  0xffff - 3,
-  0xffff - 4,
-  0xffff - 5,
+  5,
   1000000, // Calling `String.fromCharCode.apply()` with a long buffer throws a RangeError.
 ].forEach((byteLength) => {
   test(`encode and decode an array buffer whose length is ${byteLength}`, () => {
     const data = createDummyArrayBuffer(byteLength);
-    const encDeced = str2ab(ab2str(data));
+    const encDeced = base64ToAb(abTobase64(data));
     expect(new Uint8Array(encDeced)).toEqual(new Uint8Array(data));
   });
 });
@@ -52,7 +47,7 @@ test("vitest matcher for ArrayBuffer", () => {
   const applyMax = 3;
   test(`encoder with an input longer than or equal (${byteLength}) applyMax (${applyMax})`, () => {
     const data = createDummyArrayBuffer(byteLength);
-    const encDeced = str2ab(ab2str(data, applyMax));
+    const encDeced = base64ToAb(abTobase64(data, applyMax));
     expect(new Uint8Array(encDeced)).toEqual(new Uint8Array(data));
   });
 });

--- a/packages/sharing-common/src/buffer.ts
+++ b/packages/sharing-common/src/buffer.ts
@@ -1,41 +1,11 @@
-// Conversion between string and ArrayBuffer.
-// Ref: https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
-
-interface StringifiedArrayBuffer {
-  str: string;
-  padded: boolean;
-}
-
 /**
  * Ad-hoc value that works at least on Chromium: 105.0.5195.102（Official Build） （arm64）.
  * Decrease this if `RangeError: Maximum call stack size exceeded` is reported.
  */
 const DEFAULT_APPLY_MAX = 2 ** 16;
 
-export function ab2str(
-  buf: ArrayBuffer,
-  applyMax?: number
-): StringifiedArrayBuffer {
-  if (buf.byteLength % 2 !== 0) {
-    // Uint16Array only accepts ArrayBuffer whose length is a multiple of 2,
-    // so pad zero at the last 1 byte if the buffer does not meet this requirement.
-    // We can avoid this problem by using Uint8Array instead,
-    // however, Uint16Array is DOUBLE efficient than Uint8Array,
-    // so we prefer Uint16Array with this hack.
-    // Due to this padding, the additional info `.padded` is needed at the decoding time.
-    const padded = new ArrayBuffer(buf.byteLength + 1);
-    const paddedBufView = new Uint8Array(padded);
-    paddedBufView.set(new Uint8Array(buf), 0);
-
-    const stringified = ab2str(padded);
-    stringified.padded = true;
-    return stringified;
-  }
-
-  // String is represented in UTF-16, so we use Uint16Array as an encoder.
-  // See https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
-  const bufView = new Uint16Array(buf);
-
+export function abTobase64(buf: ArrayBuffer, applyMax?: number): string {
+  const bufView = new Uint8Array(buf);
   // If `bufView` is too long, `String.fromCharCode.apply(null, bufView)`
   // throws `RangeError: Maximum call stack size exceeded`,
   // so we split the buffer into chunks and process them one by one.
@@ -46,24 +16,18 @@ export function ab2str(
     const chunk = bufView.slice(offset, offset + DEFAULT_APPLY_MAX);
     str += String.fromCharCode.apply(null, chunk as unknown as number[]);
   }
-  return {
-    str,
-    padded: false,
-  };
+
+  return window.btoa(str);
 }
 
-export function str2ab(stringified: StringifiedArrayBuffer) {
-  const str = stringified.str;
+export function base64ToAb(base64: string): ArrayBuffer {
+  const s = window.atob(base64);
 
-  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
-  const bufView = new Uint16Array(buf);
-  for (let i = 0, strLen = str.length; i < strLen; i++) {
-    bufView[i] = str.charCodeAt(i);
+  const len = s.length;
+  const buf = new ArrayBuffer(len);
+  const bufView = new Uint8Array(buf);
+  for (let i = 0; i < len; i++) {
+    bufView[i] = s.charCodeAt(i);
   }
-
-  if (stringified.padded) {
-    return buf.slice(0, -1);
-  } else {
-    return buf;
-  }
+  return buf;
 }

--- a/packages/sharing-common/src/compress.ts
+++ b/packages/sharing-common/src/compress.ts
@@ -1,10 +1,19 @@
-import LZString from "lz-string";
 import { AppData } from "./proto/models";
-import { ab2str, str2ab } from "./buffer";
+import { abTobase64, base64ToAb } from "./buffer";
+
+// Conversion between base64 and hash-safe string.
+// Ref: https://gist.github.com/tomfordweb/bcb36baaa6db538b28d2f9a155debe0f
+function base64ToHashSafe(base64: string): string {
+  return base64.replace("+", "-").replace("/", "_").replace("=", ",");
+}
+
+function hashSafeToBase64(hashSafe: string): string {
+  return hashSafe.replace("-", "+").replace("_", "/").replace(",", "=");
+}
 
 export function encodeAppData(appData: AppData): string {
   const encodedProto = AppData.encode(appData).finish();
-  // NOTE: Both `ab2str(encodedProto)` and `ab2str(new Uint8Array(encodedProto))` causes an error: https://github.com/whitphx/stlite/issues/235
+  // NOTE: Both `abTobase64(encodedProto)` and `abTobase64(new Uint8Array(encodedProto))` causes an error: https://github.com/whitphx/stlite/issues/235
   //       Creating a new array buffer with `Uint8Array.from(encodedProto).buffer` and passing it as below is necessary.
   //
   // `encodedProto` is NOT Uint8Array but Buffer, although it is typed as Uint8Array (we can find it by printing it with `console.log(encodedProto)`).
@@ -15,26 +24,12 @@ export function encodeAppData(appData: AppData): string {
   // `new Uint8Array(buffer)` may provide the direct accessor to the underlying binary data in the original Buffer instance,
   // and the data read from the Uint8Array instance can differ from the one from the buffer.
   // So, we need to create a new array buffer with `Uint8Array.from()` sourced from the data read through the buffer interface here.
-  const { str, padded } = ab2str(Uint8Array.from(encodedProto).buffer);
-  const prefix = padded ? "1" : "0";
-  return prefix + LZString.compressToEncodedURIComponent(str);
+  const base64 = abTobase64(Uint8Array.from(encodedProto).buffer);
+  return base64ToHashSafe(base64);
 }
 
 export function decodeAppData(urlString: string): AppData {
-  const prefix = urlString.slice(0, 1);
-  const compressedString = urlString.slice(1);
-
-  if (prefix !== "0" && prefix !== "1") {
-    throw new Error(`Invalid prefix: "${prefix}"`);
-  }
-
-  const padded = prefix === "1" ? true : false;
-  const decompressed =
-    LZString.decompressFromEncodedURIComponent(compressedString);
-  if (decompressed == null) {
-    throw new Error("Failed to decompress");
-  }
-
-  const encodedProto = str2ab({ str: decompressed, padded });
-  return AppData.decode(new Uint8Array(encodedProto));
+  const base64 = hashSafeToBase64(urlString);
+  const buf = base64ToAb(base64);
+  return AppData.decode(new Uint8Array(buf));
 }

--- a/packages/sharing-common/src/compress.ts
+++ b/packages/sharing-common/src/compress.ts
@@ -1,13 +1,15 @@
 import { AppData } from "./proto/models";
 import { abTobase64, base64ToAb } from "./buffer";
 
-// Conversion between base64 and hash-safe string.
-// Ref: https://gist.github.com/tomfordweb/bcb36baaa6db538b28d2f9a155debe0f
-function base64ToHashSafe(base64: string): string {
+// Conversion between base64 and base64url
+// * https://gist.github.com/tomfordweb/bcb36baaa6db538b28d2f9a155debe0f
+// * https://en.wikipedia.org/wiki/Base64
+// * https://datatracker.ietf.org/doc/html/rfc4648#section-5
+function b64ToB64url(base64: string): string {
   return base64.replace("+", "-").replace("/", "_").replace("=", ",");
 }
 
-function hashSafeToBase64(hashSafe: string): string {
+function b64urlToB64(hashSafe: string): string {
   return hashSafe.replace("-", "+").replace("_", "/").replace(",", "=");
 }
 
@@ -25,11 +27,11 @@ export function encodeAppData(appData: AppData): string {
   // and the data read from the Uint8Array instance can differ from the one from the buffer.
   // So, we need to create a new array buffer with `Uint8Array.from()` sourced from the data read through the buffer interface here.
   const base64 = abTobase64(Uint8Array.from(encodedProto).buffer);
-  return base64ToHashSafe(base64);
+  return b64ToB64url(base64);
 }
 
-export function decodeAppData(urlString: string): AppData {
-  const base64 = hashSafeToBase64(urlString);
+export function decodeAppData(base64url: string): AppData {
+  const base64 = b64urlToB64(base64url);
   const buf = base64ToAb(base64);
   return AppData.decode(new Uint8Array(buf));
 }

--- a/packages/sharing-common/vitest.config.ts
+++ b/packages/sharing-common/vitest.config.ts
@@ -6,7 +6,6 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   test: {
-    /* for example, use global to avoid globals imports (describe, test, expect): */
-    // globals: true,
+    environment: "jsdom", // stlite-kernel uses jsdom, so use the same here too.
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,11 +3699,6 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
-"@types/lz-string@^1.3.34":
-  version "1.3.34"
-  resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.34.tgz#69bfadde419314b4a374bf2c8e58659c035ed0a5"
-  integrity sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==
-
 "@types/mapbox-gl@*":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.0.2.tgz#79dc50459b61bbcfd053ea93867a8b365f8f32dd"


### PR DESCRIPTION
Resolves #254

For the current default project including  `logo192.png`,
* The current encoding:
  * 7706 bytes
* `Uint8ArrayToString` + `window.btoa` is better than the current implementation in the combination with `LZString.compressToEncodedURIComponent`
  * 6544 bytes
  ```ts
  function uint8ArrayToString(buf: Uint8Array): string {
    let result = "";
    for (let i = 0; i < buf.length; i++) {
      result += String.fromCharCode(buf[i]);
    }
    return result;
  }

  export function encodeAppData(appData: AppData): string {
    const encodedProto = AppData.encode(appData).finish();
    const str = uint8ArrayToString(Uint8Array.from(encodedProto));
    const base64 = window.btoa(str);
    return LZString.compressToEncodedURIComponent(base64)
  }
  ```
* Moreover, Base64 and `LZString.compressToEncodedURIComponent` use [the character pools with the same size](https://github.com/pieroxy/lz-string/blob/2f749bc9fe3cc889fa9e32d2769a930d977596e6/libs/lz-string.js#L14-L15) (64chars), so converting base64 string with this method is inefficient. A base64 string can directly be converted into URL-safe string (base64url) by simply replacing some characters because they both can be represented by LTE 64 characters.
  * 4912 bytes
  * -> This PR.