### PR TITLE
Add onError to handle errors in the init process and display the error with a toast on @stlite/sharing

### DIFF
--- a/packages/sharing/src/App.tsx
+++ b/packages/sharing/src/App.tsx
@@ -94,6 +94,17 @@ st.write("Hello World")`,
         const onLoad: StliteKernelOptions["onLoad"] = () => {
           toastIds.forEach((id) => toast.dismiss(id));
         };
+        const onError: StliteKernelOptions["onError"] = (error) => {
+          toast(<InstallErrorToastContent error={error} />, {
+            position: toast.POSITION.BOTTOM_RIGHT,
+            type: "error",
+            autoClose: false,
+            closeOnClick: false,
+            style: {
+              cursor: "default", // react-toastify@9.0.8 sets `cursor: pointer` even for toasts with closeOnClick=false, so override it here. Ref: https://github.com/fkhadra/react-toastify/issues/839
+            },
+          });
+        };
 
         const kernel = new StliteKernel({
           command: "run",
@@ -102,6 +113,7 @@ st.write("Hello World")`,
           requirements: appData.requirements,
           onProgress,
           onLoad,
+          onError,
         });
         setKernel(kernel);
 

--- a/packages/stlite-kernel/src/kernel.ts
+++ b/packages/stlite-kernel/src/kernel.ts
@@ -66,6 +66,8 @@ export interface StliteKernelOptions {
   onProgress?: (message: string) => void;
 
   onLoad?: () => void;
+
+  onError?: (error: Error) => void;
 }
 
 export class StliteKernel {
@@ -83,12 +85,15 @@ export class StliteKernel {
 
   private onLoad: StliteKernelOptions["onLoad"];
 
+  private onError: StliteKernelOptions["onError"];
+
   constructor(options: StliteKernelOptions) {
     this.basePath = (options.basePath ?? window.location.pathname)
       .replace(FINAL_SLASH_RE, "")
       .replace(INITIAL_SLASH_RE, "");
     this.onProgress = options.onProgress;
     this.onLoad = options.onLoad;
+    this.onError = options.onError;
 
     this._worker = new Worker();
     this._worker.onmessage = (e) => {
@@ -257,6 +262,10 @@ export class StliteKernel {
       }
       case "event:progress": {
         this.onProgress && this.onProgress(msg.data.message);
+        break;
+      }
+      case "event:error": {
+        this.onError && this.onError(msg.data.error);
         break;
       }
       case "event:loaded": {

--- a/packages/stlite-kernel/src/types.d.ts
+++ b/packages/stlite-kernel/src/types.d.ts
@@ -113,6 +113,12 @@ interface ProgressEventMessage extends OutMessageBase {
     message: string;
   };
 }
+interface ErrorEventMessage extends OutMessageBase {
+  type: "event:error";
+  data: {
+    error: Error;
+  };
+}
 interface LoadedEventMessage extends OutMessageBase {
   type: "event:loaded";
 }
@@ -132,6 +138,7 @@ interface HttpResponseMessage extends OutMessageBase {
 type OutMessage =
   | StartEventMessage
   | ProgressEventMessage
+  | ErrorEventMessage
   | LoadedEventMessage
   | WebSocketBackMessage
   | HttpResponseMessage;

--- a/packages/stlite-kernel/src/worker.ts
+++ b/packages/stlite-kernel/src/worker.ts
@@ -268,7 +268,14 @@ async function loadPyodideAndPackages() {
   });
 }
 
-const pyodideReadyPromise = loadPyodideAndPackages();
+const pyodideReadyPromise = loadPyodideAndPackages().catch((error) => {
+  ctx.postMessage({
+    type: "event:error",
+    data: {
+      error,
+    },
+  });
+});
 
 /**
  * Process a message sent to the worker.


### PR DESCRIPTION
Resolves #287
Rel #26