### PR TITLE
Add the .basePath field on SampleAppManifest model to preserve the directory name

### DIFF
--- a/packages/sharing-editor/bin/gen-sample-app-manifests-json.ts
+++ b/packages/sharing-editor/bin/gen-sample-app-manifests-json.ts
@@ -18,6 +18,7 @@ type SampleAppRawManifest = Static<typeof SampleAppRawManifest>;
 const SampleAppManifest = SampleAppRawManifest.extend({
   files: Array(String),
   requirements: Array(String),
+  basePath: String,
 });
 type SampleAppManifest = Static<typeof SampleAppManifest>;
 
@@ -84,6 +85,7 @@ async function parseManifestAndFiles(
     ...rawManifest,
     files,
     requirements,
+    basePath: sampleAppDirName,
   };
 }
 

--- a/packages/sharing-editor/src/sample-app.ts
+++ b/packages/sharing-editor/src/sample-app.ts
@@ -62,7 +62,7 @@ export async function loadSampleAppData(sampleAppId: string | null) {
 
   const files = await loadFiles(
     sampleAppManifest["files"],
-    sampleAppManifest.id
+    sampleAppManifest.basePath
   );
 
   const appData: AppData = {


### PR DESCRIPTION
Fix  #378