### PR TITLE
Remove the Python patch version specification in the CI workflows because the strict version combinations of Python and OS sometimes break

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
         target: ["mountable"]
 
     env:
-      python-version: "3.10.2"
+      python-version: "3.10"
       node-version: "16.x"
       # To avoid an error like "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory".
       # See https://github.com/actions/virtual-environments/issues/70#issuecomment-653886422

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,7 +238,7 @@ jobs:
     needs: [test-kernel, test-tornado-e2e]
 
     env:
-      python-version: "3.10.2"
+      python-version: "3.10"
       node-version: "16.x"
       # To avoid an error like "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory".
       # See https://github.com/actions/virtual-environments/issues/70#issuecomment-653886422
@@ -361,7 +361,7 @@ jobs:
     needs: [test-kernel, test-tornado-e2e, test-mountable]
 
     env:
-      python-version: "3.10.2"
+      python-version: "3.10"
       node-version: "16.x"
       # To avoid an error like "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory".
       # See https://github.com/actions/virtual-environments/issues/70#issuecomment-653886422
@@ -484,7 +484,7 @@ jobs:
     needs: [test-kernel, test-tornado-e2e, test-sharing-common]
 
     env:
-      python-version: "3.10.2"
+      python-version: "3.10"
       node-version: "16.x"
       # To avoid an error like "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory".
       # See https://github.com/actions/virtual-environments/issues/70#issuecomment-653886422
@@ -654,7 +654,7 @@ jobs:
     needs: [test-kernel, test-tornado-e2e, test-desktop]
 
     env:
-      python-version: "3.10.2"
+      python-version: "3.10"
       node-version: "16.x"
       # To avoid an error like "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory".
       # See https://github.com/actions/virtual-environments/issues/70#issuecomment-653886422
@@ -777,7 +777,7 @@ jobs:
     needs: [test-desktop]
 
     env:
-      python-version: "3.10.2"
+      python-version: "3.10"
       node-version: "16.x"
       # To avoid an error like "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory".
       # See https://github.com/actions/virtual-environments/issues/70#issuecomment-653886422


### PR DESCRIPTION
Resolves #411

We give up making the Python version in the CI workflows sync to the Python version on the Pyodide runtime at the patch version level.