### PR TITLE
fix/desktop csp

### DIFF
--- a/packages/desktop/craco.config.js
+++ b/packages/desktop/craco.config.js
@@ -31,30 +31,33 @@ module.exports = {
         // For <script /> tag permissions.
         // - 'self': The main scripts
         // - 'unsafe-inline': Allow the inline scripts from custom components
-        // - *: Custom components may load arbitrary third party scripts from the Internet.
-        "script-src-elem 'self' 'unsafe-inline' *",
+        // - https: : Custom components may load arbitrary third party scripts from the Internet. We only allow HTTPS for a security sake.
+        "script-src-elem 'self' 'unsafe-inline' https:",
         // For stylesheets.
         // - 'self': For the stylesheet files bundled with the core.
         // - 'unsafe-inline': The core frontend uses some inline stylesheets.
-        // - *: Custom components may load arbitrary remote stylesheets, e.g. streamlit_folium.
-        "style-src-elem 'self' 'unsafe-inline' *",
+        // - https: : Custom components may load arbitrary remote stylesheets, e.g. streamlit_folium.
+        "style-src-elem 'self' 'unsafe-inline' https:",
         // - 'self': For font files bundled with Streamlit core, for example, for `st.latex()`.
         // - data: Some custom components load fonts through `data:` scheme, e.g. streamlit_aggrid.
         "font-src 'self' data:",
         // For loading external resources.
         // - `cspSourceForMap`:  The hosted Pyodide files, wheels, and some remote resources
-        // - *: Allow fetch() and XMLHttpRequest to load any resources (*).
-        isEnvProduction && `connect-src ${cspSourceForMap} 'self' *`,
+        // - https: : Allow fetch() and XMLHttpRequest to load any resources via HTTPS.
+        isEnvProduction && `connect-src ${cspSourceForMap} 'self' https:`,
         isEnvDevelopment &&
-          `connect-src ${cspSourceForMap} https://cdn.jsdelivr.net/ https://pypi.org/ https://files.pythonhosted.org/ http://localhost:3000/ ws://localhost:3000/ *`,
-        // Allow <img> to load any resources. blob: is necessary for st.pyplot, data: is for st.map
-        "img-src * blob: data:",
-        // Allow <audio> and <video> to load any resources
-        "media-src * blob:",
+          `connect-src ${cspSourceForMap} https://cdn.jsdelivr.net/ https://pypi.org/ https://files.pythonhosted.org/ http://localhost:3000/ ws://localhost:3000/ https:`,
+        // Allow <img> to load any resources.
+        // - blob: : For st.pyplot
+        // - data: : For st.map
+        // - file: : For some built-in image files such as the loading GIF animation and images for st.balloon(). TODO: We wanted to restrict the
+        "img-src https: blob: data: file:",
+        // Allow <audio> and <video> to load any resources.
+        "media-src https: blob:",
         // For iframe sources.
         // `st.video()` creates an iframe for a YouTube video loading resources from https://*.youtube.com.
-        // In addition, custom components may create iframes loading arbitrary external resources (*).
-        "frame-src *",
+        // In addition, custom components may create iframes loading arbitrary external resources. We allow only HTTPS for a security sake..
+        "frame-src https:",
       ]
         .filter(Boolean)
         .join("; ");

--- a/packages/desktop/craco.config.js
+++ b/packages/desktop/craco.config.js
@@ -22,8 +22,9 @@ module.exports = {
         "https://data.streamlit.io/ https://*.mapbox.com/";
       const csp = [
         "default-src 'self'",
-        // For the Wasm code. Ref: https://chromestatus.com/feature/5499765773041664, https://github.com/WebAssembly/content-security-policy/issues/7
-        "script-src 'wasm-unsafe-eval'",
+        // - 'wasm-unsafe-eval': For the Wasm code. Ref: https://chromestatus.com/feature/5499765773041664, https://github.com/WebAssembly/content-security-policy/issues/7
+        // - 'unsafe-eval': For some components such as st.*_chart() or custom components such as streamlit_hiplot. Electron shows a warning about it, but we have to use this policy...
+        "script-src 'wasm-unsafe-eval' 'unsafe-eval'",
         // style-src is necessary because of emotion. In dev, style-loader with injectType=styleTag is also the reason.
         "style-src 'self' 'unsafe-inline'",
         // The worker is inlined as blob: https://github.com/whitphx/stlite/blob/v0.7.1/packages/stlite-kernel/src/kernel.ts#L16

--- a/packages/desktop/craco.config.js
+++ b/packages/desktop/craco.config.js
@@ -40,8 +40,9 @@ module.exports = {
         // - https: : Custom components may load arbitrary remote stylesheets, e.g. streamlit_folium.
         "style-src-elem 'self' 'unsafe-inline' https:",
         // - 'self': For font files bundled with Streamlit core, for example, for `st.latex()`.
-        // - data: Some custom components load fonts through `data:` scheme, e.g. streamlit_aggrid.
-        "font-src 'self' data:",
+        // - data: : Some custom components load fonts through `data:` scheme, e.g. streamlit_aggrid.
+        // - https: : Some custom components load fonts from remote via HTTPS, e.g. streamlit_folium.
+        "font-src 'self' data: https:",
         // For loading external resources.
         // - `cspSourceForMap`:  The hosted Pyodide files, wheels, and some remote resources
         // - https: : Allow fetch() and XMLHttpRequest to load any resources via HTTPS.


### PR DESCRIPTION
- Replace * with https: in the CSP
- Add 'unsafe-eval' to script-src that is necessary for some interactive components such as st.*_chart()
- Add https: to font-src CSP
