### PR TITLE
Set browserslist as same as the Streamlit frontend package so that Babel can transpile some modern syntax that will be introduced to the Streamlit codebase

### DIFF
--- a/packages/mountable/package.json
+++ b/packages/mountable/package.json
@@ -114,18 +114,12 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
   "jest": {
     "roots": [
       "<rootDir>/src"

--- a/packages/sharing/package.json
+++ b/packages/sharing/package.json
@@ -34,18 +34,12 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
   "devDependencies": {
     "raw-loader": "^4.0.2"
   }


### PR DESCRIPTION
This is a part of upgrading the `streamlit` submodule from v1.13.0 to v1.17.0.
A modern syntax has been introduced to `streamlit/frontend` since v1.17.0 such as [this](https://github.com/streamlit/streamlit/pull/5913/files#diff-845917f3a07167e741db444532fae1e083d5b9f84ac8e8e38d3a34818a311ad8R242) and it causes an error at Babel transpiling with the current browser compatibility settings on `@stlite/mountable` and `@stlite/desktop`.
So we upgraded the settings to be same as the one defined at `streamlit/frontend/package.json` so that it can be transpiled.