### PR TITLE
Fix modifying matplotlib backend after installing it adapting to the new stlite-server package

### DIFF
--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -384,7 +384,8 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
           .then(() => {
             if (requirements.includes("matplotlib")) {
               return pyodide.runPythonAsync(`
-                bootstrap._fix_matplotlib_crash()
+                from stlite_server.bootstrap import _fix_matplotlib_crash
+                _fix_matplotlib_crash()
               `);
             }
           })


### PR DESCRIPTION
Rel: #492 .
This fix should have been introduced in #492 but not.