### PR TITLE
Support st.spinner using asyncio instead of threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ st.title("Page 2")
 
 As _stlite_ runs on the web browser environment ([Pyodide](https://pyodide.org/) runtime), there are things not working well. The known issues follow.
 
-- `st.spinner()` is no-op.
+- `st.spinner()` does not work with blocking methods like `pyodide.http.open_url()` because stlite runs on a single-threaded environment, so `st.spinner()` can't execute its code to start showing the spinner during the blocking method occupies the only event loop.
 - `st.progress()` does not show the progress bar during the script execution, but shows only the last state after the execution finishes.
 - `time.sleep()` is no-op. This is a problem at Pyodide runtime. See https://github.com/pyodide/pyodide/issues/2354
 - `st.experimental_data_editor` does not work as it relies on PyArrow, but it doesn't work on Pyodide. Track this issue on https://github.com/whitphx/stlite/issues/509.

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -194,22 +194,10 @@ async function loadPyodideAndPackages() {
     "Mocking some Streamlit functions for the browser environment."
   );
   console.debug("Mocking some Streamlit functions");
-  // Mock `st.spinner` that does not work well with Pyodide. See https://github.com/whitphx/stlite/issues/64#issuecomment-1274084568
-  // We also need to mock the `spinner` objects imported to some internal modules, e.g. the caching function modules. Ref: https://github.com/whitphx/stlite/pull/472#issuecomment-1420376555
-  await pyodide.runPythonAsync(`
-    import streamlit
-    import contextlib
-
-    @contextlib.contextmanager
-    def spinner(*args, **kwargs):
-        yield
-
-    streamlit.spinner = spinner
-    streamlit.runtime.caching.cache_utils.spinner = spinner
-    streamlit.runtime.legacy_caching.caching.spinner = spinner
-  `);
   // Disable caching. See https://github.com/whitphx/stlite/issues/495
   await pyodide.runPythonAsync(`
+    import streamlit
+
     def is_cacheable_msg(msg):
         return False
 


### PR DESCRIPTION
The idea introduced at https://github.com/whitphx/stlite/issues/64#issuecomment-1274084568 has been correct, and we can now test it with `asyncio.sleep()` because top-level await has been supported since (#514 ).
Then we implement the idea in the actual code to support `st.spinner`.