### PR TITLE
Override the page link base URL on VSCode WebViews to prevent the page links from opening unnecessary browser tabs

### DIFF
--- a/packages/kernel/src/streamlit-replacements/lib/ConnectionManager.ts
+++ b/packages/kernel/src/streamlit-replacements/lib/ConnectionManager.ts
@@ -2,6 +2,7 @@
 // and WebsocketConnection.
 
 import { BackMsg, ForwardMsg } from "streamlit-browser/src/autogen/proto"
+import { IAllowedMessageOriginsResponse } from "streamlit-browser/src/hocs/withHostCommunication/types"
 import { BaseUriParts } from "streamlit-browser/src/lib/UriUtil"
 import { ReactNode } from "react"
 
@@ -34,6 +35,12 @@ interface Props {
    * Called when our ConnectionState is changed.
    */
   connectionStateChanged: (connectionState: ConnectionState) => void
+
+  /**
+   * Function to set the list of origins that this app should accept
+   * cross-origin messages from (if in a relevant deployment scenario).
+   */
+  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void
 }
 
 export class ConnectionManager {
@@ -54,6 +61,7 @@ export class ConnectionManager {
 
     this.props.kernel.loaded.then(() => {
       console.log("The kernel has been loaded. Start connecting.")
+      this.props.setAllowedOriginsResp(this.props.kernel.allowedOriginsResp)
       this.connect()
     })
   }

--- a/packages/kernel/tsconfig.json
+++ b/packages/kernel/tsconfig.json
@@ -30,7 +30,9 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "src/lib/*": ["../../streamlit/frontend/src/lib/*"],
-      "src/autogen/*": ["../../streamlit/frontend/src/autogen/*"]
+      "src/autogen/*": ["../../streamlit/frontend/src/autogen/*"],
+      "src/theme": ["../../streamlit/frontend/src/theme"],
+      "src/theme/*": ["../../streamlit/frontend/src/theme/*"],
     },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -5,6 +5,7 @@ export interface SimplifiedStliteKernelOptions {
   entrypoint?: string;
   requirements?: StliteKernelOptions["requirements"];
   files?: StliteKernelOptions["files"] | SimplifiedFiles;
+  allowedOriginsResp?: StliteKernelOptions["allowedOriginsResp"];
 }
 
 function canonicalizeFiles(
@@ -54,5 +55,6 @@ export function canonicalizeMountOptions(
     entrypoint: options.entrypoint || DEFAULT_ENTRYPOINT,
     files,
     requirements: options.requirements || [],
+    allowedOriginsResp: options.allowedOriginsResp,
   };
 }

--- a/packages/vscode-stlite/src/web/extension.ts
+++ b/packages/vscode-stlite/src/web/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
               panel?.webview.postMessage({
                 stCommVersion: 1,
                 type: "SET_PAGE_LINK_BASE_URL",
-                pageLinkBaseUrl: "vscode-webview://",
+                pageLinkBaseUrl: "vscode-webview://stlite",
               });
               return;
             }

--- a/packages/vscode-stlite/src/web/extension.ts
+++ b/packages/vscode-stlite/src/web/extension.ts
@@ -45,6 +45,9 @@ export function activate(context: vscode.ExtensionContext) {
       panel.webview.onDidReceiveMessage(
         (message) => {
           console.debug("Received message from webview:", message);
+          // NOTE: There are both types of messages from the webview,
+          //       messages defined for stlite's functionality, and
+          //       Streamlit's iframe messages transmitted from `withHostCommunication` HOC and relayed by the mocked `window.parent.postMessage` in the WebView,
           switch (message.type) {
             case "init:done": {
               panelInitializedPromise.resolve();
@@ -120,6 +123,7 @@ export function activate(context: vscode.ExtensionContext) {
           entrypoint,
           files,
           allowedOriginsResp: {
+            // The `withHostCommunication` HOC in Streamlit's frontend accepts messages from the parent window on these hosts.
             allowedOrigins: [
               "vscode-webview://*", // For VSCode desktop
               "https://*.vscode-cdn.net", // For vscode.dev

--- a/packages/vscode-stlite/src/web/extension.ts
+++ b/packages/vscode-stlite/src/web/extension.ts
@@ -244,8 +244,6 @@ function getWebviewContent(stliteVersion: string) {
             vscode.postMessage(msg);
           }
         };
-        // Calling history.pushState inside WebView causes a page transition on the parent editor window, so we need to mock it.
-        window.history.pushState = (...args) => {};
 
         let stliteCtx = null;
 

--- a/packages/vscode-stlite/src/web/extension.ts
+++ b/packages/vscode-stlite/src/web/extension.ts
@@ -39,14 +39,27 @@ export function activate(context: vscode.ExtensionContext) {
         context.subscriptions
       );
 
-      panel.webview.html = getWebviewContent(STLITE_VERSION);
       panelInitializedPromise = new PromiseDelegate();
+      panel.webview.html = getWebviewContent(STLITE_VERSION);
 
       panel.webview.onDidReceiveMessage(
         (message) => {
+          console.debug("Received message from webview:", message);
           switch (message.type) {
             case "init:done": {
               panelInitializedPromise.resolve();
+              return;
+            }
+            case "GUEST_READY": {
+              // Override the base URL for page links in MPA to solve the problem of https://github.com/whitphx/stlite/issues/519.
+              // On vscode.dev, the base URL is set as `https://...` because `window.location.protocol` is `https://` and it is used as https://github.com/streamlit/streamlit/blob/1.19.0/frontend/src/components/core/Sidebar/SidebarNav.tsx#L106,
+              // however, links with such href values in WebView panels on vscode.dev will open new tabs when clicked even if the `onClick` handler is set and `e.preventDefault()` is called.
+              // So, we have to override the base URL with the `vscode-webview://` protocol, which does not open new tabs on vscode.dev.
+              panel?.webview.postMessage({
+                stCommVersion: 1,
+                type: "SET_PAGE_LINK_BASE_URL",
+                pageLinkBaseUrl: "vscode-webview://",
+              });
               return;
             }
           }
@@ -106,6 +119,13 @@ export function activate(context: vscode.ExtensionContext) {
           requirements,
           entrypoint,
           files,
+          allowedOriginsResp: {
+            allowedOrigins: [
+              "vscode-webview://*", // For VSCode desktop
+              "https://*.vscode-cdn.net", // For vscode.dev
+            ],
+            useExternalAuthToken: false,
+          },
         }; // NOTE: This must be JSON-encodable.
         initStlite(stliteMountOpts);
 
@@ -209,15 +229,18 @@ function getWebviewContent(stliteVersion: string) {
     </head>
     <body>
       <div id="root"></div>
-      <script>
-      // Streamlit's withHostCommunication accesses window.parent.postMessage, which is not available in the webview, so we need to mock it.
-      window.parent = { postMessage: () => {} };
-      // Calling history.pushState inside WebView causes a page transition on the parent editor window, so we need to mock it.
-      window.history.pushState = () => {};
-      </script>
       <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@${stliteVersion}/build/stlite.js"></script>
       <script>
         const vscode = acquireVsCodeApi();
+
+        // Streamlit's withHostCommunication accesses window.parent.postMessage, which is not available in the webview, so we need to mock it.
+        window.parent = {
+          postMessage: (msg) => {
+            vscode.postMessage(msg);
+          }
+        };
+        // Calling history.pushState inside WebView causes a page transition on the parent editor window, so we need to mock it.
+        window.history.pushState = (...args) => {};
 
         let stliteCtx = null;
 

--- a/packages/vscode-stlite/src/web/extension.ts
+++ b/packages/vscode-stlite/src/web/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
           console.debug("Received message from webview:", message);
           // NOTE: There are both types of messages from the webview,
           //       messages defined for stlite's functionality, and
-          //       Streamlit's iframe messages transmitted from `withHostCommunication` HOC and relayed by the mocked `window.parent.postMessage` in the WebView,
+          //       Streamlit's iframe messages transmitted from the `withHostCommunication` HOC and relayed by the mocked `window.parent.postMessage` in the WebView,
           switch (message.type) {
             case "init:done": {
               panelInitializedPromise.resolve();
@@ -56,8 +56,9 @@ export function activate(context: vscode.ExtensionContext) {
             case "GUEST_READY": {
               // Override the base URL for page links in MPA to solve the problem of https://github.com/whitphx/stlite/issues/519.
               // On vscode.dev, the base URL is set as `https://...` because `window.location.protocol` is `https://` and it is used as https://github.com/streamlit/streamlit/blob/1.19.0/frontend/src/components/core/Sidebar/SidebarNav.tsx#L106,
-              // however, links with such href values in WebView panels on vscode.dev will open new tabs when clicked even if the `onClick` handler is set and `e.preventDefault()` is called.
-              // So, we have to override the base URL with the `vscode-webview://` protocol, which does not open new tabs on vscode.dev.
+              // however, links with such href values in WebView panels on vscode.dev will open unnecessary new tabs
+              // when clicked even if the `onClick` handler is set and `e.preventDefault()` is called.
+              // So, we have to override the base URL with the `vscode-webview://` protocol, which doesn't open new tabs on vscode.dev.
               panel?.webview.postMessage({
                 stCommVersion: 1,
                 type: "SET_PAGE_LINK_BASE_URL",


### PR DESCRIPTION
Resolves  #519