### PR TITLE
Remove handler on the Electron app when the window is closed

### DIFF
--- a/packages/desktop/electron/main.ts
+++ b/packages/desktop/electron/main.ts
@@ -61,6 +61,11 @@ const createWindow = () => {
     }
   );
 
+  mainWindow.on("closed", () => {
+    ipcMain.removeHandler("readSitePackagesSnapshot");
+    ipcMain.removeHandler("readStreamlitAppDirectory");
+  });
+
   // Even when the entrypoint is a local file like the production build,
   // we use .loadURL() with an absolute URL with the `file://` schema
   // instead of passing a file path to .loadFile()


### PR DESCRIPTION
Resolves #546