### PR TITLE
feature/specify pyodide url

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -4,7 +4,7 @@ import StreamlitApp from "./StreamlitApp";
 import { makeToastKernelCallbacks } from "@stlite/common-react";
 import "@stlite/common-react/src/toastify-components/toastify.css";
 
-let pyodideEntrypointUrl: string | undefined;
+let pyodideUrl: string | undefined;
 if (process.env.NODE_ENV === "production") {
   // The `pyodide` directory including `pyodide.js` is downloaded
   // to the build target directory at the build time for production release.
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV === "production") {
   // We set the path here to be loaded in the worker via `importScript()`.
   const currentURL = window.location.href;
   const parentURL = currentURL.split("/").slice(0, -1).join("/") + "/";
-  pyodideEntrypointUrl = parentURL + "pyodide/pyodide.js";
+  pyodideUrl = parentURL + "pyodide/pyodide.js";
 }
 
 function App() {
@@ -53,7 +53,7 @@ function App() {
           archives: [],
           requirements,
           mountedSitePackagesSnapshotFilePath,
-          pyodideEntrypointUrl,
+          pyodideUrl,
           ...makeToastKernelCallbacks(),
         });
         setKernel(kernel);

--- a/packages/kernel/src/declarations.d.ts
+++ b/packages/kernel/src/declarations.d.ts
@@ -9,9 +9,6 @@ declare module "*.whl" {
   return res;
 }
 
-// Declarations for worker.ts where some variables are dynamically loaded through importScript.
-declare let loadPyodide: any;
-
 // Declarations for the `self` object in worker.ts some of whose properties are used to share values with the Python environment.
 interface Window {
   __logCallback__: (msg: string) => void;

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -59,7 +59,7 @@ export interface StliteKernelOptions {
    * The URL of `pyodide.js` or `pyodide.mjs` to be loaded in the worker.
    * If not specified, the default one is used.
    */
-  pyodideEntrypointUrl?: string;
+  pyodideUrl?: string;
 
   /**
    *
@@ -170,7 +170,7 @@ export class StliteKernel {
       files: options.files,
       archives: options.archives,
       requirements: options.requirements,
-      pyodideEntrypointUrl: options.pyodideEntrypointUrl,
+      pyodideUrl: options.pyodideUrl,
       wheels,
       mountedSitePackagesSnapshotFilePath:
         options.mountedSitePackagesSnapshotFilePath,

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -56,7 +56,7 @@ export interface StliteKernelOptions {
   archives: Array<PyodideArchive | PyodideArchiveUrl>;
 
   /**
-   * The URL of `pyodide.js` to be loaded via `importScripts()` in the worker.
+   * The URL of `pyodide.js` or `pyodide.mjs` to be loaded in the worker.
    * If not specified, the default one is used.
    */
   pyodideEntrypointUrl?: string;

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -34,7 +34,7 @@ export interface WorkerInitialData {
   files: Record<string, EmscriptenFile | EmscriptenFileUrl>;
   archives: Array<PyodideArchive | PyodideArchiveUrl>;
   requirements: string[];
-  pyodideEntrypointUrl?: string;
+  pyodideUrl?: string;
   wheels?: {
     stliteServer: string;
     streamlit: string;

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -55,6 +55,9 @@ async function initPyodide(
   return loadPyodide({ ...loadPyodideOptions, indexURL: indexUrl });
 }
 
+const DEFAULT_PYODIDE_URL =
+  "https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js";
+
 /**
  * Load Pyodided and initialize the interpreter.
  *
@@ -72,15 +75,12 @@ async function loadPyodideAndPackages() {
     requirements,
     wheels,
     mountedSitePackagesSnapshotFilePath,
-    pyodideEntrypointUrl,
+    pyodideUrl = DEFAULT_PYODIDE_URL,
   } = await initDataPromiseDelegate.promise;
 
   postProgressMessage("Loading Pyodide.");
 
   console.debug("Loading Pyodide");
-  const pyodideUrl =
-    pyodideEntrypointUrl ??
-    "https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js";
   pyodide = await initPyodide(pyodideUrl, {
     stdout: console.log,
     stderr: console.error,

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -1,4 +1,4 @@
-import type { PyodideInterface } from "pyodide";
+import type Pyodide from "pyodide";
 import { PromiseDelegate } from "@lumino/coreutils";
 import { writeFileWithParents, renameWithParents } from "./file";
 import { verifyRequirements } from "./requirements";
@@ -10,7 +10,7 @@ import {
   ReplyMessageHttpResponse,
 } from "./types";
 
-let pyodide: PyodideInterface;
+let pyodide: Pyodide.PyodideInterface;
 
 let httpServer: any;
 
@@ -31,6 +31,28 @@ function postProgressMessage(message: string): void {
       message,
     },
   });
+}
+
+async function initPyodide(
+  pyodideUrl: string,
+  loadPyodideOptions: Parameters<typeof Pyodide.loadPyodide>[0]
+): Promise<Pyodide.PyodideInterface> {
+  // Ref: https://github.com/jupyterlite/pyodide-kernel/blob/v0.1.3/packages/pyodide-kernel/src/kernel.ts#L55
+  const indexUrl = pyodideUrl.slice(0, pyodideUrl.lastIndexOf("/") + 1);
+
+  // Ref: https://github.com/jupyterlite/pyodide-kernel/blob/v0.1.3/packages/pyodide-kernel/src/worker.ts#L40-L54
+  let loadPyodide: typeof Pyodide.loadPyodide;
+  if (pyodideUrl.endsWith(".mjs")) {
+    // note: this does not work at all in firefox
+    const pyodideModule: typeof Pyodide = await import(
+      /* webpackIgnore: true */ pyodideUrl
+    );
+    loadPyodide = pyodideModule.loadPyodide;
+  } else {
+    importScripts(pyodideUrl);
+    loadPyodide = (self as any).loadPyodide;
+  }
+  return loadPyodide({ ...loadPyodideOptions, indexURL: indexUrl });
 }
 
 /**
@@ -55,14 +77,11 @@ async function loadPyodideAndPackages() {
 
   postProgressMessage("Loading Pyodide.");
 
-  console.debug("Import the entrypoint script.");
-  importScripts(
-    pyodideEntrypointUrl ??
-      "https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js"
-  );
-
   console.debug("Loading Pyodide");
-  pyodide = await loadPyodide({
+  const pyodideUrl =
+    pyodideEntrypointUrl ??
+    "https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js";
+  pyodide = await initPyodide(pyodideUrl, {
     stdout: console.log,
     stderr: console.error,
   });
@@ -94,7 +113,7 @@ async function loadPyodideAndPackages() {
   postProgressMessage("Unpacking archives.");
   await Promise.all(
     archives.map(async (archive) => {
-      let buffer: Parameters<PyodideInterface["unpackArchive"]>[0];
+      let buffer: Parameters<Pyodide.PyodideInterface["unpackArchive"]>[0];
       if ("url" in archive) {
         console.debug(`Fetch an archive from ${archive.url}`);
         buffer = await fetch(archive.url).then((res) => res.arrayBuffer());

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -10,6 +10,7 @@ export interface SimplifiedStliteKernelOptions {
   >;
   archives?: StliteKernelOptions["archives"];
   allowedOriginsResp?: StliteKernelOptions["allowedOriginsResp"];
+  pyodideUrl?: StliteKernelOptions["pyodideEntrypointUrl"];
 }
 
 function canonicalizeFiles(
@@ -99,5 +100,6 @@ export function canonicalizeMountOptions(
     archives,
     requirements: options.requirements || [],
     allowedOriginsResp: options.allowedOriginsResp,
+    pyodideEntrypointUrl: options.pyodideUrl,
   };
 }

--- a/packages/mountable/src/options.ts
+++ b/packages/mountable/src/options.ts
@@ -10,7 +10,7 @@ export interface SimplifiedStliteKernelOptions {
   >;
   archives?: StliteKernelOptions["archives"];
   allowedOriginsResp?: StliteKernelOptions["allowedOriginsResp"];
-  pyodideUrl?: StliteKernelOptions["pyodideEntrypointUrl"];
+  pyodideUrl?: StliteKernelOptions["pyodideUrl"];
 }
 
 function canonicalizeFiles(
@@ -100,6 +100,6 @@ export function canonicalizeMountOptions(
     archives,
     requirements: options.requirements || [],
     allowedOriginsResp: options.allowedOriginsResp,
-    pyodideEntrypointUrl: options.pyodideUrl,
+    pyodideUrl: options.pyodideUrl,
   };
 }


### PR DESCRIPTION
- Update the kernel to load Pyodide both with .js and .mjs and make the mountable package to accept `pyodideUrl` option to use it
- Rename `pyodideEntrypointUrl` to `pyodideUrl`, which is same as the JupyterLite codebase
