### PR TITLE
Triggering build to see if CI works

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A port of [Streamlit](https://streamlit.io/) to WebAssembly, powered by [Pyodide
 
 Streamlit is a Python web app framework for the fast development of data apps. This project is to make it run completely on web browsers.
 
-## Try it out
+## Try it out now
 
 Visit [stlite sharing](https://edit.share.stlite.net/).
 


### PR DESCRIPTION
I struggle with a version conflict when I run latest master locally and in my own CI, so was hoping to test the build here to see if it is special case with my copy. I get 

```
ERROR: Cannot install streamlit[snowflake]==1.24.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    streamlit[snowflake] 1.24.0 depends on pillow<10 and >=6.2.0
    The user requested (constraint) pillow==10.1.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```