### PR TITLE
Upgrade Pyodide to 0.24.1

### DIFF
--- a/packages/desktop/bin/dump_artifacts.ts
+++ b/packages/desktop/bin/dump_artifacts.ts
@@ -97,9 +97,9 @@ async function loadPyodideBuiltinPackageData(): Promise<
     { name: string; version: string; file_name: string; depends: string[] }
   >
 > {
-  const url = makePyodideUrl("repodata.json");
+  const url = makePyodideUrl("pyodide-lock.json");
 
-  console.log(`Load the Pyodide repodata.json from ${url}`);
+  console.log(`Load the Pyodide pyodide-lock.json from ${url}`);
   const res = await fetch(url);
   const resJson = await res.json();
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -19,7 +19,7 @@
     "eject": "craco eject",
     "start:electron": "tsc -p electron -w",
     "build:electron": "tsc -p electron",
-    "build:pyodide": "curl -L https://github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-core-0.23.3.tar.bz2 | tar xj -C ./build --files-from=./pyodide-files.txt",
+    "build:pyodide": "curl -L https://github.com/pyodide/pyodide/releases/download/0.24.1/pyodide-core-0.24.1.tar.bz2 | tar xj -C ./build --files-from=./pyodide-files.txt",
     "build:bin": "./scripts/build_bin.js && sed -i'' -e '1 s/^#!.*$/#!\\/usr\\/bin\\/env node/' ./bin/*.js",
     "typecheck": "yarn tsc --noEmit -p electron",
     "start": "concurrently \"cross-env BROWSER=none yarn start:web\" \"wait-on http://localhost:3000 && yarn start:electron\" \"wait-on http://localhost:3000 && tsc -p electron && cross-env NODE_ENV=\"development\" electron .\"",
@@ -53,7 +53,7 @@
   "dependencies": {
     "fs-extra": "^10.1.0",
     "node-fetch": "2",
-    "pyodide": "0.23.3",
+    "pyodide": "0.24.1",
     "yargs": "^17.5.1"
   },
   "devDependencies": {

--- a/packages/desktop/pyodide-files.txt
+++ b/packages/desktop/pyodide-files.txt
@@ -2,4 +2,4 @@ pyodide/pyodide.asm.js
 pyodide/pyodide.asm.wasm
 pyodide/pyodide.js
 pyodide/python_stdlib.zip
-pyodide/repodata.json
+pyodide/pyodide-lock.json

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -26,7 +26,7 @@
     "eslint": "^8.33.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "pyodide": "0.23.3",
+    "pyodide": "0.24.1",
     "typescript": "^4.9.4",
     "vitest": "^0.21.1"
   },

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -56,7 +56,7 @@ async function initPyodide(
 }
 
 const DEFAULT_PYODIDE_URL =
-  "https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js";
+  "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js";
 
 /**
  * Load Pyodided and initialize the interpreter.

--- a/yarn.lock
+++ b/yarn.lock
@@ -15663,7 +15663,7 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
+node-fetch@2, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -17779,13 +17779,12 @@ pure-color@^1.2.0:
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
   integrity sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==
 
-pyodide@0.23.3:
-  version "0.23.3"
-  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.23.3.tgz#eb123f3d9d1223b6194fe965edf2f83cf2a9c87c"
-  integrity sha512-t95Nu73ENjwoRhThmxvZIHMD7GXTJ3uOt/E0sJ1TxjBvoU/qPys4SV08FtZBMEnpMRKFzE4uecvx2c0qybSZhw==
+pyodide@0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.24.1.tgz#c03da27a6f63c7e19e031258c4168498106ee7f6"
+  integrity sha512-fkNolNwiv41E2KKCP2bgW+dwr95B+0KSC/WG9WCmlWM9MNFbRVX0rF9i4OikRM78bGeVUvLdVJw8jY17wxKoRQ==
   dependencies:
     base-64 "^1.0.0"
-    node-fetch "^2.6.1"
     ws "^8.5.0"
 
 q@^1.1.2, q@^1.5.1:


### PR DESCRIPTION
For newer versions of Streamlit (approx. >=1.27.0?), this Pyodide version is necessary for the Pillow's version match.