### PR TITLE
Ship the stlite wheel files with the desktop package

### DIFF
--- a/packages/desktop/.gitignore
+++ b/packages/desktop/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 !.env
 
 /bin/*.js
+/wheels

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -26,7 +26,7 @@
     "typecheck": "yarn tsc --noEmit -p electron",
     "start": "concurrently \"cross-env BROWSER=none yarn start:web\" \"wait-on http://localhost:3000 && yarn start:electron\" \"wait-on http://localhost:3000 && tsc -p electron && cross-env NODE_ENV=\"development\" electron .\"",
     "build:app": "yarn build:web && yarn build:electron && yarn build:pyodide",
-    "build": "yarn build:app && yarn build:bin",
+    "build": "yarn build:app && yarn build:wheels && yarn build:bin",
     "dump:dev": "ts-node ./bin/dump_artifacts.ts",
     "dump": "dump-stlite-desktop-artifacts",
     "serve": "cross-env NODE_ENV=production electron .",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -6,7 +6,8 @@
   "main": "./build/electron/main.js",
   "files": [
     "build",
-    "bin/*.js"
+    "bin/*.js",
+    "wheels"
   ],
   "bin": {
     "dump-stlite-desktop-artifacts": "./bin/dump_artifacts.js"
@@ -21,6 +22,7 @@
     "build:electron": "tsc -p electron",
     "build:pyodide": "curl -L https://github.com/pyodide/pyodide/releases/download/0.24.1/pyodide-core-0.24.1.tar.bz2 | tar xj -C ./build --files-from=./pyodide-files.txt",
     "build:bin": "./scripts/build_bin.js && sed -i'' -e '1 s/^#!.*$/#!\\/usr\\/bin\\/env node/' ./bin/*.js",
+    "build:wheels": "./scripts/copy_wheels.js",
     "typecheck": "yarn tsc --noEmit -p electron",
     "start": "concurrently \"cross-env BROWSER=none yarn start:web\" \"wait-on http://localhost:3000 && yarn start:electron\" \"wait-on http://localhost:3000 && tsc -p electron && cross-env NODE_ENV=\"development\" electron .\"",
     "build:app": "yarn build:web && yarn build:electron && yarn build:pyodide",

--- a/packages/desktop/scripts/build_bin.js
+++ b/packages/desktop/scripts/build_bin.js
@@ -9,7 +9,6 @@ require("esbuild")
     minify: true,
     platform: "node",
     external: [
-      "@stlite/kernel", // Don't touch `require.resolve("@stlite/kernel") at the bundle time.
       "pyodide", // The `pyodide` package must be installed at runtime for the included Wasm files, so there is no reason to bundle it here.
       "node-fetch", // `node-fetch` will be installed at runtime anyway because it is one dependency of the `pyodide` package, so there is no reason to bundle it here.
       "fs-extra", // `fs-extra` and `yargs` will be installed at runtime anyway as the dependencies of `electron-builder`, so we don't have to bundle them here.

--- a/packages/desktop/scripts/copy_wheels.js
+++ b/packages/desktop/scripts/copy_wheels.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+// Copy wheels from the `@stlite/kernel` package to the `wheels` directory.
+
+const fs = require("fs-extra");
+const path = require("path");
+
+async function copyFileToDir(filePath, dirPath) {
+  const fileName = path.basename(filePath);
+  const destPath = path.join(dirPath, fileName);
+  await fs.copy(filePath, destPath);
+}
+
+async function main() {
+  const stliteKernelDir = path.dirname(require.resolve("@stlite/kernel")); // -> /path/to/kernel/dist
+  const stliteKernelPyDir = path.resolve(stliteKernelDir, "../py"); // -> /path/to/kernel/py
+
+  // TODO: Set the wheel file names dynamically
+  const stliteServerWheelPath = path.join(
+    stliteKernelPyDir,
+    "stlite-server/dist/stlite_server-0.1.0-py3-none-any.whl"
+  );
+  const streamlitWheelPath = path.join(
+    stliteKernelPyDir,
+    "streamlit/lib/dist/streamlit-1.30.0-cp311-none-any.whl"
+  );
+
+  // Create the `wheels` directory if it doesn't exist
+  const wheelsDir = path.join(__dirname, "../wheels");
+
+  if (await fs.pathExists(wheelsDir)) {
+    await fs.emptyDir(wheelsDir);
+  } else {
+    await fs.mkdir(wheelsDir);
+  }
+
+  // Copy the wheels to the `wheels` directory
+  await copyFileToDir(stliteServerWheelPath, wheelsDir);
+  await copyFileToDir(streamlitWheelPath, wheelsDir);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/desktop/scripts/copy_wheels.js
+++ b/packages/desktop/scripts/copy_wheels.js
@@ -2,13 +2,13 @@
 
 // Copy wheels from the `@stlite/kernel` package to the `wheels` directory.
 
-const fs = require("fs-extra");
+const fsPromises = require("fs/promises");
 const path = require("path");
 
 async function copyFileToDir(filePath, dirPath) {
   const fileName = path.basename(filePath);
   const destPath = path.join(dirPath, fileName);
-  await fs.copy(filePath, destPath);
+  await fsPromises.copyFile(filePath, destPath);
 }
 
 async function main() {
@@ -25,14 +25,14 @@ async function main() {
     "streamlit/lib/dist/streamlit-1.30.0-cp311-none-any.whl"
   );
 
-  // Create the `wheels` directory if it doesn't exist
+  // Create the `wheels` directory
   const wheelsDir = path.join(__dirname, "../wheels");
-
-  if (await fs.pathExists(wheelsDir)) {
-    await fs.emptyDir(wheelsDir);
-  } else {
-    await fs.mkdir(wheelsDir);
+  if (
+    await fsPromises.stat(wheelsDir).catch((error) => error.code !== "ENOENT")
+  ) {
+    await fsPromises.rm(wheelsDir, { recursive: true });
   }
+  await fsPromises.mkdir(wheelsDir);
 
   // Copy the wheels to the `wheels` directory
   await copyFileToDir(stliteServerWheelPath, wheelsDir);


### PR DESCRIPTION
Prepare for #687.
After this change is published, `@stlite/kernel` can stop being published.