### PR TITLE
Set `moduleResolution` as `Node` because it's necessary to run correct type checking at build time

### DIFF
--- a/packages/desktop/src/nodejs-worker.ts
+++ b/packages/desktop/src/nodejs-worker.ts
@@ -10,7 +10,7 @@ export class NodeJsWorkerMock {
   constructor() {
     this.initializePromise = window.nodeJsWorkerAPI.initialize();
 
-    window.nodeJsWorkerAPI.onMessage((data) => {
+    window.nodeJsWorkerAPI.onMessage((data: unknown) => {
       this.onmessage && this.onmessage({ data });
     });
   }

--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/packages/mountable/tsconfig.json
+++ b/packages/mountable/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/packages/sharing/tsconfig.json
+++ b/packages/sharing/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
Rel: #805