### PR TITLE
Update stlite version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Here is a sample HTML file.
     <title>stlite app</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.39.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.52.1/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.39.0/build/stlite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.52.1/build/stlite.js"></script>
     <script>
       stlite.mount(
         `


### PR DESCRIPTION
The current readme still uses a quite old version in the example. This PR updates this to the latest version.