### PR TITLE
Remove parquet-wasm deps from packages/*/package.json

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -85,7 +85,6 @@
     "electron-reload": "^2.0.0-alpha.1",
     "esbuild": "^0.20.0",
     "glob": "^10.3.12",
-    "parquet-wasm": "^0.4.0",
     "raw-loader": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/mountable/package.json
+++ b/packages/mountable/package.json
@@ -63,7 +63,6 @@
     "jest-resolve": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
     "mini-css-extract-plugin": "^2.4.5",
-    "parquet-wasm": "^0.4.0",
     "postcss": "^8.4.4",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^6.2.1",

--- a/packages/sharing/package.json
+++ b/packages/sharing/package.json
@@ -15,7 +15,6 @@
     "@types/node": "^16.18.12",
     "@types/react": "^17.0.7",
     "@types/react-dom": "^17.0.5",
-    "parquet-wasm": "^0.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",


### PR DESCRIPTION
because these packages don't depend on `parquet-wasm` while `@streamlit/lib` does and it's the only package that must have the dependency to `parquet-wasm`.