### PR TITLE
fix/dataframe parquet serialize

### DIFF
--- a/packages/kernel/src/mock.ts
+++ b/packages/kernel/src/mock.ts
@@ -14,6 +14,16 @@ class Table:
     @classmethod
     def from_pandas(*args, **kwargs):
         raise NotImplementedError("stlite is not supporting this method.")
+
+
+class Array:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("stlite is not supporting PyArrow.Array")
+
+
+class ChunkedArray:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("stlite is not supporting PyArrow.ChunkedArray")
 """
     }
 )


### PR DESCRIPTION
- Update streamlit submodule to fix Parquet serialization of NumPy array values
- Add mocks of PyArrow.Array and .ChunkedArray
