### PR TITLE
Remove the mountedSitePackagesSnapshotFilePath option and use the archive option instead

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -45,21 +45,22 @@ function App() {
           };
         });
 
-        const mountedSitePackagesSnapshotFilePath =
-          "/tmp/site-packages-snapshot.tar.gz";
         kernel = new StliteKernel({
           entrypoint: window.appConfig.entrypoint,
-          files: {
-            ...files,
-            [mountedSitePackagesSnapshotFilePath]: {
-              data: sitePackagesSnapshotFileBin,
+          files,
+          archives: [
+            {
+              buffer: sitePackagesSnapshotFileBin,
+              format: "gztar",
+              options: {
+                extractDir: "/",
+              },
             },
-          },
-          archives: [],
+          ],
           requirements: [],
           prebuiltPackageNames,
-          mountedSitePackagesSnapshotFilePath,
           pyodideUrl,
+          skipStliteWheelsInstall: true,
           idbfsMountpoints: window.appConfig.idbfsMountpoints,
           worker: USE_NODEJS_WORKER
             ? (new NodeJsWorkerMock() as unknown as Worker)

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -77,11 +77,7 @@ export interface StliteKernelOptions {
    */
   wheelBaseUrl?: string;
 
-  /**
-   * If specified, the worker restores the site-packages directories from this archive file
-   * and skip installing the wheels and required packages.
-   */
-  mountedSitePackagesSnapshotFilePath?: string;
+  skipStliteWheelsInstall?: boolean;
 
   /**
    * In the original Streamlit, the `hostConfig` endpoint returns a value of this type
@@ -182,7 +178,7 @@ export class StliteKernel {
     };
 
     let wheels: WorkerInitialData["wheels"] = undefined;
-    if (options.mountedSitePackagesSnapshotFilePath == null) {
+    if (!options.skipStliteWheelsInstall) {
       console.debug("Custom wheel URLs:", {
         STLITE_SERVER_WHEEL,
         STREAMLIT_WHEEL,
@@ -215,8 +211,6 @@ export class StliteKernel {
       prebuiltPackageNames: options.prebuiltPackageNames,
       pyodideUrl: options.pyodideUrl,
       wheels,
-      mountedSitePackagesSnapshotFilePath:
-        options.mountedSitePackagesSnapshotFilePath,
       streamlitConfig: options.streamlitConfig,
       idbfsMountpoints: options.idbfsMountpoints,
       moduleAutoLoad: options.moduleAutoLoad ?? false,

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -53,7 +53,6 @@ export interface WorkerInitialData {
     stliteServer: string;
     streamlit: string;
   };
-  mountedSitePackagesSnapshotFilePath?: string;
   streamlitConfig?: StreamlitConfig;
   idbfsMountpoints?: string[];
   nodefsMountpoints?: Record<string, string>;


### PR DESCRIPTION
The `archives` option was introduced in #567 after `mountedSitePackagesSnapshotFilePath` in #295 so now we can replace `mountedSitePackagesSnapshotFilePath` with `archives` for the same purpose for the simplicity sake.