### PR TITLE
[DO NOT MERGE] Package the prebuilt packages required by the Streamlit and the Stlit…

### DIFF
--- a/packages/kernel/src/declarations.d.ts
+++ b/packages/kernel/src/declarations.d.ts
@@ -8,3 +8,8 @@ declare module "*.whl" {
   const res: string;
   return res;
 }
+
+declare module "*.tar.gz" {
+  const res: string;
+  return res;
+}

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -33,6 +33,7 @@ import { assertStreamlitConfig } from "./types";
 // https://pyodide.org/en/stable/project/changelog.html#micropip
 import STLITE_LIB_WHEEL from "!!file-loader?name=pypi/[name].[ext]&context=.!../py/stlite-lib/dist/stlite_lib-0.1.0-py3-none-any.whl"; // TODO: Extract the import statement to an auto-generated file like `_pypi.ts` in JupyterLite: https://github.com/jupyterlite/jupyterlite/blob/f2ecc9cf7189cb19722bec2f0fc7ff5dfd233d47/packages/pyolite-kernel/src/_pypi.ts
 import STREAMLIT_WHEEL from "!!file-loader?name=pypi/[name].[ext]&context=.!../py/streamlit/lib/dist/streamlit-1.36.0-cp312-none-any.whl";
+import PREBUILT_PACKAGES_ARCHIVE from "!!file-loader?context=.!../assets/pyodide_archive.tar.gz";
 
 // Ref: https://github.com/streamlit/streamlit/blob/1.12.2/frontend/src/lib/UriUtil.ts#L32-L33
 const FINAL_SLASH_RE = /\/+$/;
@@ -211,6 +212,8 @@ export class StliteKernel {
       prebuiltPackageNames: options.prebuiltPackageNames,
       pyodideUrl: options.pyodideUrl,
       wheels,
+      prebuiltPackagesArchiveUrl:
+        PREBUILT_PACKAGES_ARCHIVE as unknown as string,
       streamlitConfig: options.streamlitConfig,
       idbfsMountpoints: options.idbfsMountpoints,
       moduleAutoLoad: options.moduleAutoLoad ?? false,

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -53,6 +53,7 @@ export interface WorkerInitialData {
     stliteLib: string;
     streamlit: string;
   };
+  prebuiltPackagesArchiveUrl?: string;
   streamlitConfig?: StreamlitConfig;
   idbfsMountpoints?: string[];
   nodefsMountpoints?: Record<string, string>;

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -221,8 +221,8 @@ export function startWorkerEnv(
 
       const DEFAULT_CHANNEL = "default channel";
 
+      const promises: Promise<void>[] = [];
       for (const path of prebuiltPackagePaths) {
-        console.debug(`Prepare the prebuilt package: ${path}`);
         const pkgData = uriToPackageData(path);
         console.log({ pkgData });
         if (!pkgData) {
@@ -257,8 +257,9 @@ export function startWorkerEnv(
           });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        await pyodide._api.loadDynlibsFromPackage(pkg, dynlibs);
+        promises.push(pyodide._api.loadDynlibsFromPackage(pkg, dynlibs));
       }
+      await Promise.all(promises);
       console.debug("Loaded the prebuilt packages snapshot");
     }
 

--- a/packages/sharing/craco.config.js
+++ b/packages/sharing/craco.config.js
@@ -13,7 +13,7 @@ module.exports = {
       // Ref: https://muguku.medium.com/fix-go-to-definition-and-hot-reload-in-a-react-typescript-monorepo-362908716d0e
       const oneOfRule = webpackConfig.module.rules.find((rule) => rule.oneOf);
       const tsRule = oneOfRule.oneOf.find((rule) =>
-        rule.test.toString().includes("ts|tsx")
+        rule.test.toString().includes("ts|tsx"),
       );
       tsRule.include = undefined;
       tsRule.exclude = /node_modules/;
@@ -53,7 +53,7 @@ module.exports = {
       // So we turn off Asset Modules here by setting `type: 'javascript/auto'`.
       // See https://webpack.js.org/guides/asset-modules/
       webpackConfig.module.rules.push({
-        test: /\.whl$/i,
+        test: /\.(whl|tar\.gz)$/i,
         use: [
           {
             loader: "file-loader",


### PR DESCRIPTION
…e wheels and load it at the initializaiton phase of the worker

`assets/pyodide_archive.tar.gz` is created as follows:
1. [`saveUsedPrebuiltPackages()`](https://github.com/whitphx/stlite/blob/38cffef277c5e185d7dbb1e9f2bf9b2ea25ec5c0/packages/desktop/bin-src/dump_artifacts/index.ts#L94) with `requirements = [stliteWheel, StreamlitWheel]`
2. The prebuilt packages required by the `requirements` are downloaded into `pyodideRuntimeDir`.
3. Package them into the archive, `tar -czf pyodide_archive.tar.gz ./pyodide/*.whl;`.