### PR TITLE
Fix the worker to await httpServer.start() that returns a promise

### DIFF
--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -395,7 +395,7 @@ prepare(main_script_path, args)
     console.debug("Booting up the Streamlit server");
     const Server = pyodide.pyimport("stlite_lib.server.Server");
     httpServer = Server(entrypoint);
-    httpServer.start();
+    await httpServer.start();
     console.debug("Booted up the Streamlit server");
 
     postMessage({


### PR DESCRIPTION
Resolves #1118

Maybe the event loop implementation of Chrome is different from Safari and this bug couldn't happen in Chrome?