### PR TITLE
Cache node_modules

### DIFF
--- a/.github/actions/init-all/action.yml
+++ b/.github/actions/init-all/action.yml
@@ -35,6 +35,9 @@ runs:
         path: '**/node_modules'
         key: node_modules-${{ hashFiles('yarn.lock') }}
 
+    - run: yarn install --frozen-lockfile
+      shell: bash
+
     # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
     # Actions are running as of 2023.05.03 - doesn't have recent versions
     # of protoc in its package repository.

--- a/.github/actions/init-all/action.yml
+++ b/.github/actions/init-all/action.yml
@@ -25,18 +25,9 @@ runs:
           **/uv.lock
 
     ## Set up Node environment
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/init-node
       with:
-        node-version-file: ${{ inputs.node-version-file }}
-        cache: 'yarn'
-
-    - uses: actions/cache@v4
-      with:
-        path: '**/node_modules'
-        key: node_modules-${{ hashFiles('yarn.lock') }}
-
-    - run: yarn install --frozen-lockfile
-      shell: bash
+        node-version-file: ${{ env.node-version-file }}
 
     # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
     # Actions are running as of 2023.05.03 - doesn't have recent versions

--- a/.github/actions/init-all/action.yml
+++ b/.github/actions/init-all/action.yml
@@ -30,6 +30,11 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: 'yarn'
 
+    - uses: actions/cache@v4
+      with:
+        path: '**/node_modules'
+        key: node_modules-${{ hashFiles('yarn.lock') }}
+
     # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
     # Actions are running as of 2023.05.03 - doesn't have recent versions
     # of protoc in its package repository.

--- a/.github/actions/init-node/action.yml
+++ b/.github/actions/init-node/action.yml
@@ -13,10 +13,21 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: 'yarn'
 
+    - name: Get Node.js version
+      id: node-version
+      run: echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+      shell: bash
+      # Include the NodeJS version in the cache key.
+      # While there are several reasons not to recommend caching `node_modules` (https://github.com/actions/setup-node/issues/304#issuecomment-886241508),
+      # NodeJS version incompatibility is one of them (https://github.com/actions/setup-node/issues/304#issuecomment-886240594).
+      # So invalidating the cache based on the NodeJS version is not perfect but
+      # it makes things safer.
+      # See also https://github.com/actions/setup-node/issues/406 and https://dev.to/flydiverny/comment/1lk25.
+
     - uses: actions/cache@v4
       with:
         path: '**/node_modules'
-        key: node_modules-${{ hashFiles('yarn.lock') }}
+        key: node_modules-${{ env.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
     # `yarn install` often takes so long time on in the Windows env.
     # https://github.com/yarnpkg/yarn/issues/8242

--- a/.github/actions/init-node/action.yml
+++ b/.github/actions/init-node/action.yml
@@ -1,0 +1,25 @@
+name: 'Node Initialization Action'
+description: 'Node initialization steps for CI jobs'
+inputs:
+  node-version-file:
+    description: 'Node version file to setup'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    ## Set up Node environment
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
+        cache: 'yarn'
+
+    - uses: actions/cache@v4
+      with:
+        path: '**/node_modules'
+        key: node_modules-${{ hashFiles('yarn.lock') }}
+
+    # `yarn install` often takes so long time on in the Windows env.
+    # https://github.com/yarnpkg/yarn/issues/8242
+    - run: yarn config set network-timeout 600000
+
+    - run: yarn install --frozen-lockfile

--- a/.github/actions/init-node/action.yml
+++ b/.github/actions/init-node/action.yml
@@ -21,5 +21,7 @@ runs:
     # `yarn install` often takes so long time on in the Windows env.
     # https://github.com/yarnpkg/yarn/issues/8242
     - run: yarn config set network-timeout 600000
+      shell: bash
 
     - run: yarn install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v4
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+
     - name: Lint
       run: |
         yarn check:eslint
@@ -176,11 +176,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v4
+
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+
     - name: Lint
       run: |
         yarn check:eslint
@@ -201,11 +202,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v4
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+
     - run: make sharing-common
       working-directory: .
     # - name: Lint
@@ -228,11 +229,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v4
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+
     - name: Lint
       run: |
         yarn check:eslint
@@ -258,12 +259,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v4
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn config set network-timeout 600000  # `yarn install` often takes so long time on in the Windows env.
-    - run: yarn install --frozen-lockfile
+
     - run: make common
       working-directory: .
     - name: Lint
@@ -488,11 +488,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: actions/setup-node@v4
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
 
     - name: Cache node_modules/.cache including Webpack's cache
       uses: actions/cache@v4
@@ -695,12 +694,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v4
+
+    - uses: ./.github/actions/init-node
       with:
         node-version-file: ${{ env.node-version-file }}
-        cache: 'yarn'
-    - run: yarn config set network-timeout 300000  # https://github.com/yarnpkg/yarn/issues/8242
-    - run: yarn install --frozen-lockfile
+
     - run: yarn playwright install
     - run: make common
     - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: init mountable sharing sharing-editor
 
 
 .PHONY: init
-init: git_submodules venv node_modules
+init: git_submodules venv yarn_install
 
 VENV := ./.venv
 NODE_MODULES := ./node_modules


### PR DESCRIPTION
`actions/setup-node` with `cache: yarn` caches Yarn's global cache instead of the installed packages in the local working directory, e.g. `node_modules` [as described](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data).
Ref: https://stackoverflow.com/questions/70201071/setup-node-restoring-cache-but-still-takes-a-while-to-yarn
Looks like it's a standard way, however, running `yarn install` takes about 40~50secs even with the global cache, so caching `node_modules` can also be an option if it introduces a drastic improvement.
Refs:
* https://tech.dentsusoken.com/entry/2024/03/25/GitHub_Actions_%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E8%A8%AD%E8%A8%88%E3%81%AETips_%EF%BD%9E%E3%82%B9%E3%83%A0%E3%83%BC%E3%82%BA%E3%81%AA%E4%BE%9D%E5%AD%98%E9%96%A2%E4%BF%82%E7%AE%A1
* https://zenn.dev/ascend/articles/github-actions-on-push-history