### PR TITLE
Set uv version in the CI workflows as !=0.5.17

### DIFF
--- a/.github/actions/init-all/action.yml
+++ b/.github/actions/init-all/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v3
       with:
-        version: "latest"
+        version: ">0.5.17 || <0.5.17"  # 0.5.17 has an issue https://github.com/astral-sh/uv/issues/10487
         enable-cache: true
         cache-dependency-glob: |
           **/requirements*.txt

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v5
       with:
-        version: "latest"
+        version: ">0.5.17 || <0.5.17"  # 0.5.17 has an issue https://github.com/astral-sh/uv/issues/10487
         enable-cache: true
         cache-dependency-glob: |
           **/requirements*.txt


### PR DESCRIPTION
The latest version of uv has an issue when creating venv as https://github.com/astral-sh/uv/issues/10487 and the CI has started to fail due to it.