### PR TITLE
Use classic workers in production for the cross origin worker trick on a page loaded via file:// scheme

### DIFF
--- a/packages/browser/src/mount.tsx
+++ b/packages/browser/src/mount.tsx
@@ -29,6 +29,10 @@ export function mount(
     ...kernelOptions,
     wheelUrls,
     ...makeToastKernelCallbacks(toastCallbackOptions),
+    workerType:
+      process.env.NODE_ENV === "development"
+        ? "module" // Vite loads the worker scripts as ES modules without bundling at dev time, so we need to specify the type as "module" for the "import" statements in the worker script to work.
+        : "classic", // type="classic" is needed for the cross-origin worker trick to work in the page loaded via `file://` scheme, so we use it for the production build.
   });
 
   // eslint-disable-next-line react/no-deprecated

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -164,8 +164,9 @@ export class StliteKernel {
       // HACK: Use `CrossOriginWorkerMaker` imported as `Worker` here.
       // Read the comment in `cross-origin-worker.ts` for the detail.
       const workerMaker = new Worker(new URL("./worker.js", import.meta.url), {
+        /* @vite-ignore */ // To avoid the Vite error: "[vite:worker-import-meta-url] Vite is unable to parse the worker options as the value is not static.To ignore this error, please use /* @vite-ignore */ in the worker options."
         type: options.workerType,
-        /* @vite-ignore */ shared: options.sharedWorker ?? false,
+        shared: options.sharedWorker ?? false,
       });
       this._worker = workerMaker.worker;
     }

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -118,11 +118,13 @@ export interface StliteKernelOptions {
 
   onError?: (error: Error) => void;
 
+  workerType?: WorkerOptions["type"];
+
   sharedWorker?: boolean;
 
   /**
    * The worker to be used, which can be optionally passed.
-   * Desktop apps with NodeJS-backed worker is one of the use cases.
+   * Desktop apps with NodeJS-backed worker is one use case.
    */
   worker?: globalThis.Worker;
 }
@@ -162,7 +164,7 @@ export class StliteKernel {
       // HACK: Use `CrossOriginWorkerMaker` imported as `Worker` here.
       // Read the comment in `cross-origin-worker.ts` for the detail.
       const workerMaker = new Worker(new URL("./worker.js", import.meta.url), {
-        type: "module", // Vite loads the worker scripts as ES modules without bundling at dev time, so we need to specify the type as "module" for the "import" statements in the worker script to work.
+        type: options.workerType,
         /* @vite-ignore */ shared: options.sharedWorker ?? false,
       });
       this._worker = workerMaker.worker;


### PR DESCRIPTION


Resolves #1246