### PR TITLE
Add env option to mount and setEnv function to kernel

### DIFF
--- a/packages/browser/src/options.ts
+++ b/packages/browser/src/options.ts
@@ -22,7 +22,7 @@ export type SimplifiedStliteKernelOptions = Partial<{
   streamlitConfig: StliteKernelOptions["streamlitConfig"];
   idbfsMountpoints: StliteKernelOptions["idbfsMountpoints"];
   sharedWorker: StliteKernelOptions["sharedWorker"];
-  executeOnInitialize: StliteKernelOptions["executeOnInitialize"];
+  env: StliteKernelOptions["env"];
 }>;
 
 function canonicalizeFiles(
@@ -134,7 +134,7 @@ export function parseMountOptions(options: MountOptions): {
       streamlitConfig: options.streamlitConfig,
       idbfsMountpoints: options.idbfsMountpoints,
       sharedWorker: options.sharedWorker,
-      executeOnInitialize: options?.executeOnInitialize,
+      env: options.env,
     },
     toastCallbackOptions: {
       disableProgressToasts: options.disableProgressToasts || false,

--- a/packages/browser/src/options.ts
+++ b/packages/browser/src/options.ts
@@ -22,6 +22,7 @@ export type SimplifiedStliteKernelOptions = Partial<{
   streamlitConfig: StliteKernelOptions["streamlitConfig"];
   idbfsMountpoints: StliteKernelOptions["idbfsMountpoints"];
   sharedWorker: StliteKernelOptions["sharedWorker"];
+  executeOnInitialize: StliteKernelOptions["executeOnInitialize"];
 }>;
 
 function canonicalizeFiles(

--- a/packages/browser/src/options.ts
+++ b/packages/browser/src/options.ts
@@ -134,6 +134,7 @@ export function parseMountOptions(options: MountOptions): {
       streamlitConfig: options.streamlitConfig,
       idbfsMountpoints: options.idbfsMountpoints,
       sharedWorker: options.sharedWorker,
+      executeOnInitialize: options?.executeOnInitialize,
     },
     toastCallbackOptions: {
       disableProgressToasts: options.disableProgressToasts || false,

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -30,6 +30,13 @@ import { assertStreamlitConfig } from "./types";
 const FINAL_SLASH_RE = /\/+$/;
 const INITIAL_SLASH_RE = /^\/+/;
 
+const validateEnvKey = (key: string) => {
+  // Validate each variable name: it must start with a letter or underscore,
+  // and can contain only letters, digits, or underscores.
+  const validEnvNameRegex = /^[A-Za-z_][A-Za-z0-9_]*$/;
+  return validEnvNameRegex.test(key);
+};
+
 export interface StliteKernelOptions {
   /**
    * The file path on the Pyodide File System (Emscripten FS) to be set as a target of the `run` command.
@@ -122,7 +129,7 @@ export interface StliteKernelOptions {
 
   sharedWorker?: boolean;
 
-  executeOnInitialize?: WorkerInitialData["executeOnInitialize"];
+  env?: Record<string, string>;
 
   /**
    * The worker to be used, which can be optionally passed.
@@ -200,7 +207,7 @@ export class StliteKernel {
       streamlitConfig: options.streamlitConfig,
       idbfsMountpoints: options.idbfsMountpoints,
       moduleAutoLoad: options.moduleAutoLoad ?? false,
-      executeOnInitialize: options.executeOnInitialize,
+      env: options.env,
     };
   }
 
@@ -309,11 +316,17 @@ export class StliteKernel {
     });
   }
 
-  public runCode(code: string): Promise<void> {
+  public setEnv(env: Record<string, string>): Promise<void> {
+    Object.keys(env).forEach((key) => {
+      if (!validateEnvKey(key)) {
+        throw new Error(`Invalid environment variable name: "${key}"`);
+      }
+    });
+
     return this._asyncPostMessage({
-      type: "runCode",
+      type: "setEnv",
       data: {
-        code,
+        env,
       },
     });
   }

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -122,6 +122,8 @@ export interface StliteKernelOptions {
 
   sharedWorker?: boolean;
 
+  executeOnInitialize?: WorkerInitialData["executeOnInitialize"];
+
   /**
    * The worker to be used, which can be optionally passed.
    * Desktop apps with NodeJS-backed worker is one use case.
@@ -198,6 +200,7 @@ export class StliteKernel {
       streamlitConfig: options.streamlitConfig,
       idbfsMountpoints: options.idbfsMountpoints,
       moduleAutoLoad: options.moduleAutoLoad ?? false,
+      executeOnInitialize: options.executeOnInitialize,
     };
   }
 

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -309,9 +309,9 @@ export class StliteKernel {
     });
   }
 
-  public execute(code: string): Promise<void> {
+  public runCode(code: string): Promise<void> {
     return this._asyncPostMessage({
-      type: "execute",
+      type: "runCode",
       data: {
         code,
       },

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -309,6 +309,15 @@ export class StliteKernel {
     });
   }
 
+  public execute(code: string): Promise<void> {
+    return this._asyncPostMessage({
+      type: "execute",
+      data: {
+        code,
+      },
+    });
+  }
+
   /**
    * Reboot the Streamlit server.
    * Note that we also need to refresh (rerender) the frontend app after calling this method

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -57,7 +57,7 @@ export interface WorkerInitialData {
   idbfsMountpoints?: string[];
   nodefsMountpoints?: Record<string, string>;
   moduleAutoLoad: boolean;
-  executeOnInitialize?: string;
+  env?: Record<string, string>;
 }
 
 /**
@@ -130,10 +130,10 @@ export interface InMessageInstall extends InMessageBase {
   };
 }
 
-export interface InMessageRunCode extends InMessageBase {
-  type: "runCode";
+export interface InMessageSetEnv extends InMessageBase {
+  type: "setEnv";
   data: {
-    code: string;
+    env: Record<string, string>;
   };
 }
 
@@ -148,7 +148,7 @@ export type InMessage =
   | InMessageFileUnlink
   | InMessageFileRead
   | InMessageInstall
-  | InMessageRunCode;
+  | InMessageSetEnv;
 
 export interface StliteWorker extends Worker {
   postMessage(message: InMessage, transfer: Transferable[]): void;

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -57,6 +57,7 @@ export interface WorkerInitialData {
   idbfsMountpoints?: string[];
   nodefsMountpoints?: Record<string, string>;
   moduleAutoLoad: boolean;
+  executeOnInitialize?: string;
 }
 
 /**

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -130,8 +130,8 @@ export interface InMessageInstall extends InMessageBase {
   };
 }
 
-export interface InMessageExecute extends InMessageBase {
-  type: "execute";
+export interface InMessageRunCode extends InMessageBase {
+  type: "runCode";
   data: {
     code: string;
   };
@@ -148,7 +148,7 @@ export type InMessage =
   | InMessageFileUnlink
   | InMessageFileRead
   | InMessageInstall
-  | InMessageExecute;
+  | InMessageRunCode;
 
 export interface StliteWorker extends Worker {
   postMessage(message: InMessage, transfer: Transferable[]): void;

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -129,6 +129,14 @@ export interface InMessageInstall extends InMessageBase {
     requirements: string[];
   };
 }
+
+export interface InMessageExecute extends InMessageBase {
+  type: "execute";
+  data: {
+    code: string;
+  };
+}
+
 export type InMessage =
   | InMessageInitData
   | InMessageReboot
@@ -139,7 +147,8 @@ export type InMessage =
   | InMessageFileRename
   | InMessageFileUnlink
   | InMessageFileRead
-  | InMessageInstall;
+  | InMessageInstall
+  | InMessageExecute;
 
 export interface StliteWorker extends Worker {
   postMessage(message: InMessage, transfer: Transferable[]): void;

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -105,6 +105,7 @@ export function startWorkerEnv(
       idbfsMountpoints,
       nodefsMountpoints,
       moduleAutoLoad,
+      executeOnInitialize,
     } = initData;
 
     const requirements = validateRequirements(unvalidatedRequirements); // Blocks the not allowed wheel URL schemes.
@@ -137,6 +138,10 @@ export function startWorkerEnv(
       }
 
       console.debug("Loaded Pyodide");
+    }
+
+    if (executeOnInitialize) {
+      await pyodide.runPythonAsync(executeOnInitialize);
     }
 
     let useIdbfs = false;

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -646,7 +646,7 @@ prepare(main_script_path, args)
             });
           break;
         }
-        case "execute": {
+        case "runCode": {
           const { code } = msg.data;
           pyodide.runPythonAsync(code).then(() => {
             console.debug("Successfully executed");

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -644,6 +644,16 @@ prepare(main_script_path, args)
                 type: "reply",
               });
             });
+          break;
+        }
+        case "execute": {
+          const { code } = msg.data;
+          pyodide.runPythonAsync(code).then(() => {
+            console.debug("Successfully executed");
+            reply({
+              type: "reply",
+            });
+          });
         }
       }
     } catch (error) {

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -138,6 +138,8 @@ export function startWorkerEnv(
       });
       pyodide = await initPyodidePromise;
       if (env) {
+        // We could've used the env parameter in pyodide initialization,
+        // but then some default environment variables like HOME were not set.
         setEnv(pyodide, env);
       }
 


### PR DESCRIPTION
At Cognite, we have a fork of `stlite` because we need to pass in an authentication token into an environment variable in Python. One way to get rid of this fork is to add the functionality in this PR:
1) a new optional field in `mount` function called `env`: A Record<string,string> object with environment variables to set on initialization.
2) a new kernel function `setEnv` that allows JavaScript to set environment variables at any time later.

It would be super for us to have these features merged into `stlite` and likely useful for other people as well for the same reasons. 