### PR TITLE
feat: add language server support in the kernel

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -134,6 +134,12 @@ export interface StliteKernelOptions {
   env?: Record<string, string>;
 
   /**
+   * Set to true to load the python language server libraries
+   * And enable methods like getCodeCompletions
+   */
+  languageServer?: boolean;
+
+  /**
    * The worker to be used, which can be optionally passed.
    * Desktop apps with NodeJS-backed worker is one use case.
    */
@@ -210,6 +216,7 @@ export class StliteKernel {
       idbfsMountpoints: options.idbfsMountpoints,
       moduleAutoLoad: options.moduleAutoLoad ?? false,
       env: options.env,
+      languageServer: options.languageServer ?? false,
     };
   }
 
@@ -336,6 +343,11 @@ export class StliteKernel {
   public getCodeCompletion(
     payload: LanguageServerRequestPayload,
   ): Promise<ReplyMessageLanguageServerCodeCompletion["data"]> {
+    if (!this._workerInitData.languageServer) {
+      throw new Error(
+        `Language server not loaded, please set languageServer=true to use this method`,
+      );
+    }
     return this._asyncPostMessage(
       {
         type: "language-server:code_completion",

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -23,6 +23,8 @@ import type {
   WorkerInitialData,
   StreamlitConfig,
   ModuleAutoLoadMessage,
+  LanguageServerRequestPayload,
+  ReplyMessageLanguageServerCodeCompletion,
 } from "./types";
 import { assertStreamlitConfig } from "./types";
 
@@ -329,6 +331,18 @@ export class StliteKernel {
         env,
       },
     });
+  }
+
+  public getCodeCompletion(
+    payload: LanguageServerRequestPayload,
+  ): Promise<ReplyMessageLanguageServerCodeCompletion["data"]> {
+    return this._asyncPostMessage(
+      {
+        type: "language-server:code_completion",
+        data: payload,
+      },
+      "reply:language-server:code_completion",
+    ).then((data) => data);
   }
 
   /**

--- a/packages/kernel/src/language-server/code_completion.ts
+++ b/packages/kernel/src/language-server/code_completion.ts
@@ -3,7 +3,7 @@ import type { PyCallable } from "pyodide/ffi";
 import { LanguageServerRequestPayload } from "../types";
 
 export const defineCodeCompletionsFunction = async (
-  pyodide: Pyodide.PyodideInterface
+  pyodide: Pyodide.PyodideInterface,
 ) => {
   // Indentation is very important in python, don't change this!
   await pyodide.runPythonAsync(
@@ -106,13 +106,13 @@ def get_code_completions(code: str, current_line_number: int, cursor_offset: int
   # Convert results to JSON so that we can use it in the worker
   converter = lsp_converters.get_converter()
   return json.dumps(converter.unstructure(suggestions, unstructure_as=CompletionList))
-`
+`,
   );
 };
 
 export const getCodeCompletions = async (
   payload: LanguageServerRequestPayload,
-  pyodide: Pyodide.PyodideInterface
+  pyodide: Pyodide.PyodideInterface,
 ) => {
   let get_code_completions: PyCallable | undefined;
   try {
@@ -121,7 +121,7 @@ export const getCodeCompletions = async (
 
     if (!get_code_completions) {
       console.error(
-        "Can not generate suggestions list, the get_code_completions function is not defined"
+        "Can not generate suggestions list, the get_code_completions function is not defined",
       );
       return { items: [] };
     }
@@ -130,7 +130,7 @@ export const getCodeCompletions = async (
     const result = get_code_completions(
       payload.code,
       payload.currentLineNumber,
-      payload.offset
+      payload.offset,
     );
 
     if (!result) {

--- a/packages/kernel/src/language-server/code_completion.ts
+++ b/packages/kernel/src/language-server/code_completion.ts
@@ -1,5 +1,3 @@
-/** Needed for the Regex bellow */
-/* eslint-disable no-useless-escape */
 import type Pyodide from "pyodide";
 import type { PyCallable } from "pyodide/ffi";
 import { LanguageServerRequestPayload } from "../types";
@@ -64,13 +62,14 @@ def as_completion_item(completion: Completion, cursor_range: Range) -> Dict:
       text_edit=TextEdit(range=cursor_range, new_text=label),
   )
 
-def get_cursor_range(cursor_code_line: str, current_line_number: int, cursor_offset: int):
+def get_text_edit_cursor_range(cursor_code_line: str, current_line_number: int, cursor_offset: int):
   # Match the substring starting from cursor_offset ex: math<cursor>co, match co
-  matched_words = re.search(r'\b\w+', cursor_code_line[cursor_offset:])
+  matched_words = re.search(r'\\b\\w+\\b', cursor_code_line[cursor_offset :])
 
   # Determine the length of the matched word characters
   word_after_cursor_length = len(matched_words.group()) if matched_words else 0
 
+  # This will tell to code editors which text to edit/replace
   return Range(
     start=Position(
         line=current_line_number, character=cursor_offset
@@ -96,8 +95,8 @@ def get_code_completions(code: str, current_line_number: int, cursor_offset: int
   if current_line_number >= len(jedi_language_server._code_lines):
     return json.dumps({ "items": []})
 
-  code_at_cursor = jedi_language_server._code_lines[current_line_number]
-  cursor_range = get_cursor_range(code_at_cursor, current_line_number, cursor_offset)
+  code_at_cursor = jedi_language_server._code_lines[current_line_number -1]
+  cursor_range = get_text_edit_cursor_range(code_at_cursor, current_line_number, cursor_offset)
 
   # Convert jedi completion items as completion items compatible in language server
   suggestions = CompletionList(

--- a/packages/kernel/src/language-server/code_completion.ts
+++ b/packages/kernel/src/language-server/code_completion.ts
@@ -1,0 +1,118 @@
+/** Needed for the Regex bellow */
+/* eslint-disable no-useless-escape */
+import type Pyodide from "pyodide";
+import { LanguageServerRequestPayload } from "../types";
+
+export const getCodeCompletions = async (
+  payload: LanguageServerRequestPayload,
+  pyodide: Pyodide.PyodideInterface,
+) => {
+  try {
+    // Indentation is very important in python, don't change this!
+    const result = await pyodide.runPythonAsync(
+      `import jedi;
+import re;
+import json;
+from typing import Dict, Iterator, List
+from lsprotocol.types import (CompletionItem, CompletionList, CompletionItemKind, Position, Range, TextEdit)
+from lsprotocol import converters as lsp_converters
+from jedi.api.classes import Completion
+
+def get_jedi_line_number(current_line_number: int) -> tuple[int, int]:
+    """Convert position to jedi position (the line is 1+ based)."""
+    return current_line_number + 1
+
+def as_completion_item_kind(kind: str):
+  match kind:
+    case 'class':
+      return CompletionItemKind.Class
+    case 'function':
+      return CompletionItemKind.Function
+    case 'instance':
+      return CompletionItemKind.Reference
+    case 'keyword':
+      return CompletionItemKind.Keyword
+    case 'module':
+      return CompletionItemKind.Module
+    case 'param':
+      return CompletionItemKind.Variable
+    case 'path':
+      return CompletionItemKind.File
+    case 'property':
+      return CompletionItemKind.Property
+    case 'statement':
+      return CompletionItemKind.Variable
+    case _:
+      return CompletionItemKind.Text
+
+def as_completion_item(completion: Completion, cursor_range: Range) -> Dict:
+  label = completion.name
+  return CompletionItem(
+      label=label,
+      filter_text=label,
+      sort_text=label,
+      kind=as_completion_item_kind(completion.type),
+      documentation=completion.docstring(raw=True),
+      text_edit=TextEdit(range=cursor_range, new_text=label),
+  )
+
+def get_cursor_range(cursor_code_line: str, current_line_number: int, cursor_offset: int):
+  # Match the substring starting from cursor_offset ex: math<cursor>co, match co
+  matched_words = re.search(r'\b\w+', cursor_code_line[cursor_offset:])
+
+  # Determine the length of the matched word characters
+  word_after_cursor_length = len(matched_words_after_cursor.group()) if matched_words else 0
+
+  return Range(
+    start=Position(
+        line=current_line_number, character=cursor_offset
+    ),
+    end=Position(
+        line=current_line_number,
+        character=cursor_offset + word_after_cursor_length,
+    ),
+  )
+
+def get_code_completions():
+
+  code = '''
+${payload.code}
+  '''
+
+
+  jedi_language_server = jedi.Script(code)
+  current_line_number = ${payload.currentLineNumber}
+  cursor_offset = ${payload.offset}
+
+  jedi_completions_list = jedi_language_server.complete(
+      get_jedi_line_number(current_line_number),
+      cursor_offset,
+      fuzzy=False,
+  )
+
+  code_at_cursor = jedi_language_server._code_lines[current_line_number]
+  cursor_range = get_cursor_range(code_at_cursor, current_line_number, cursor_offset)
+
+  # Convert jedi completion items as completion items compatible in language server
+  suggestions = CompletionList(
+    is_incomplete=False, 
+    items=list(as_completion_item(completion, cursor_range) for completion in jedi_completions_list))
+
+  # Convert results to JSON so that we can use it in the worker
+  converter = lsp_converters.get_converter()
+  return json.dumps(converter.unstructure(suggestions, unstructure_as=CompletionList))
+
+
+get_code_completions()`,
+    );
+
+    if (!result) {
+      return { items: [] };
+    }
+
+    return JSON.parse(result);
+  } catch (err) {
+    console.error(err);
+    return { items: [] };
+  }
+};

--- a/packages/kernel/src/language-server/code_completion.ts
+++ b/packages/kernel/src/language-server/code_completion.ts
@@ -9,10 +9,10 @@ export const defineCodeCompletionsFunction = async (
 ) => {
   // Indentation is very important in python, don't change this!
   await pyodide.runPythonAsync(
-    `import jedi;
-import re;
-import json;
-from typing import Dict, Iterator, List
+    `import jedi
+import re
+import json
+from typing import Dict
 from lsprotocol.types import (CompletionItem, CompletionList, CompletionItemKind, Position, Range, TextEdit)
 from lsprotocol import converters as lsp_converters
 from jedi.api.classes import Completion

--- a/packages/kernel/src/language-server/language-server-loader.ts
+++ b/packages/kernel/src/language-server/language-server-loader.ts
@@ -1,5 +1,6 @@
 import type Pyodide from "pyodide";
 import type { PyProxy } from "pyodide/ffi";
+import { defineCodeCompletionsFunction } from "./code_completion";
 
 /**
  * Imports the necessary python packages to enable language server features
@@ -9,11 +10,12 @@ export const importLanguageServerLibraries = async (
   micropip: PyProxy,
 ) => {
   try {
+    console.debug("Importing jedi Interpreter");
     await micropip.install.callKwargs(["jedi", "lsprotocol"], {
       keep_going: true,
     });
     await pyodide.runPythonAsync(`import jedi`);
-    console.debug("Importing jedi Interpreter");
+    await defineCodeCompletionsFunction(pyodide);
   } catch (err) {
     console.error("Error while importing jedi", err);
   }

--- a/packages/kernel/src/language-server/language-server-loader.ts
+++ b/packages/kernel/src/language-server/language-server-loader.ts
@@ -7,7 +7,7 @@ import { defineCodeCompletionsFunction } from "./code_completion";
  */
 export const importLanguageServerLibraries = async (
   pyodide: Pyodide.PyodideInterface,
-  micropip: PyProxy
+  micropip: PyProxy,
 ) => {
   try {
     console.debug("Importing jedi Interpreter");

--- a/packages/kernel/src/language-server/language-server-loader.ts
+++ b/packages/kernel/src/language-server/language-server-loader.ts
@@ -1,0 +1,20 @@
+import type Pyodide from "pyodide";
+import type { PyProxy } from "pyodide/ffi";
+
+/**
+ * Imports the necessary python packages to enable language server features
+ */
+export const importLanguageServerLibraries = async (
+  pyodide: Pyodide.PyodideInterface,
+  micropip: PyProxy,
+) => {
+  try {
+    await micropip.install.callKwargs(["jedi", "lsprotocol"], {
+      keep_going: true,
+    });
+    await pyodide.runPythonAsync(`import jedi`);
+    console.debug("Importing jedi Interpreter");
+  } catch (err) {
+    console.error("Error while importing jedi", err);
+  }
+};

--- a/packages/kernel/src/language-server/language-server-loader.ts
+++ b/packages/kernel/src/language-server/language-server-loader.ts
@@ -7,14 +7,13 @@ import { defineCodeCompletionsFunction } from "./code_completion";
  */
 export const importLanguageServerLibraries = async (
   pyodide: Pyodide.PyodideInterface,
-  micropip: PyProxy,
+  micropip: PyProxy
 ) => {
   try {
     console.debug("Importing jedi Interpreter");
     await micropip.install.callKwargs(["jedi", "lsprotocol"], {
       keep_going: true,
     });
-    await pyodide.runPythonAsync(`import jedi`);
     await defineCodeCompletionsFunction(pyodide);
   } catch (err) {
     console.error("Error while importing jedi", err);

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -58,6 +58,7 @@ export interface WorkerInitialData {
   nodefsMountpoints?: Record<string, string>;
   moduleAutoLoad: boolean;
   env?: Record<string, string>;
+  languageServer?: boolean;
 }
 
 /**

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -137,6 +137,17 @@ export interface InMessageSetEnv extends InMessageBase {
   };
 }
 
+export interface LanguageServerRequestPayload {
+  code: string;
+  currentLine: string;
+  currentLineNumber: number;
+  offset: number;
+}
+export interface InMessageCodeCompletion extends InMessageBase {
+  type: "language-server:code_completion";
+  data: LanguageServerRequestPayload;
+}
+
 export type InMessage =
   | InMessageInitData
   | InMessageReboot
@@ -148,7 +159,8 @@ export type InMessage =
   | InMessageFileUnlink
   | InMessageFileRead
   | InMessageInstall
-  | InMessageSetEnv;
+  | InMessageSetEnv
+  | InMessageCodeCompletion;
 
 export interface StliteWorker extends Worker {
   postMessage(message: InMessage, transfer: Transferable[]): void;
@@ -239,6 +251,21 @@ export interface ReplyMessageFileRead extends ReplyMessageBase {
     content: string | Uint8Array;
   };
 }
+
+export interface LanguageServerCodeCompletionResponse {
+  /**
+   * Decided to use unknown to avoid importing whole package and bunch of stuff
+   * from monaco-editor package that we don't need it here at all
+   * https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.CompletionItem.html
+   *
+   */
+  items: unknown[];
+}
+export interface ReplyMessageLanguageServerCodeCompletion
+  extends ReplyMessageBase {
+  type: "reply:language-server:code_completion";
+  data: LanguageServerCodeCompletionResponse;
+}
 export interface ReplyMessageGeneralReply extends ReplyMessageBase {
   type: "reply";
   error?: Error;
@@ -246,6 +273,7 @@ export interface ReplyMessageGeneralReply extends ReplyMessageBase {
 export type ReplyMessage =
   | ReplyMessageHttpResponse
   | ReplyMessageFileRead
+  | ReplyMessageLanguageServerCodeCompletion
   | ReplyMessageGeneralReply;
 
 /**

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -33,7 +33,7 @@ interface InitializeWorkerEnvOptions {
   languageServer?: boolean;
 }
 async function initializeWorkerEnv(
-  options: InitializeWorkerEnvOptions,
+  options: InitializeWorkerEnvOptions
 ): Promise<PyodideInterface> {
   const pyodideLoader: typeof import("./pyodide-loader") =
     await vitest.importActual("./pyodide-loader");
@@ -79,10 +79,10 @@ async function initializeWorkerEnv(
             entrypoint: options.entrypoint,
             wheels: {
               stliteLib: getWheelInstallPath(
-                stliteLibWheelUrl as unknown as string,
+                stliteLibWheelUrl as unknown as string
               ),
               streamlit: getWheelInstallPath(
-                streamlitWheelUrl as unknown as string,
+                streamlitWheelUrl as unknown as string
               ),
             },
             archives: [],
@@ -92,7 +92,7 @@ async function initializeWorkerEnv(
             languageServer: options.languageServer ?? false,
           },
         },
-      }),
+      })
     );
   });
 }
@@ -109,7 +109,7 @@ const TEST_SOURCES: {
     files: {
       "data.column_config.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/data.column_config.py",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/data.column_config.py"
       ),
     },
   },
@@ -118,7 +118,7 @@ const TEST_SOURCES: {
     files: {
       "chat.echo.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.echo.py",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.echo.py"
       ),
     },
   },
@@ -127,15 +127,15 @@ const TEST_SOURCES: {
     files: {
       "media.logo.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/media.logo.py",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/media.logo.py"
       ),
       "pages/images/horizontal_red.png": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/images/horizontal_red.png",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/images/horizontal_red.png"
       ),
       "pages/images/icon_red.png": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/images/icon_red.png",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/images/icon_red.png"
       ),
     },
   },
@@ -145,7 +145,7 @@ const TEST_SOURCES: {
     files: {
       "text.write_stream.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/text.write_stream.py",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/text.write_stream.py"
       ),
     },
     additionalAppTestCode: `
@@ -159,7 +159,7 @@ await at.run(timeout=20)
     files: {
       "layout.columns2.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/layout.columns2.py",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/layout.columns2.py"
       ),
     },
   },
@@ -184,9 +184,9 @@ suite("Worker intergration test running an app", async () => {
               async ([filename, filepath]) => {
                 const content = await fsPromises.readFile(filepath);
                 return [filename, { data: content }];
-              },
-            ),
-          ),
+              }
+            )
+          )
         );
 
         const pyodide = await initializeWorkerEnv({
@@ -197,7 +197,7 @@ suite("Worker intergration test running an app", async () => {
 
         pyodide.globals.set(
           "__additionalAppTestCode__",
-          testSource.additionalAppTestCode,
+          testSource.additionalAppTestCode
         );
 
         // The code above setting up the worker env is good enough to check if the worker is set up correctly,
@@ -227,7 +227,7 @@ assert len(w) == 0, f"Warning occurred: {w[0].message if w else None}"
       },
       {
         timeout: 60 * 1000,
-      },
+      }
     );
   }
 });
@@ -240,7 +240,7 @@ suite(
       vitest.resetModules();
       const filePath = path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py",
+        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py"
       );
       const content = await fsPromises.readFile(filePath);
 
@@ -266,14 +266,14 @@ st.te
           code: code,
           currentLine: "st.te",
           currentLineNumber: 2,
-          offset: 5,
+          offset: 3,
         },
-        pyodide as PyodideInterface,
+        pyodide as PyodideInterface
       );
 
       // Should give suggestions for the word after the comma
       expect(
-        autocompleteResults.items.map((item: { label: string }) => item.label),
+        autocompleteResults.items.map((item: { label: string }) => item.label)
       ).toEqual(expect.arrayContaining(["text", "text_area", "text_input"]));
     });
 
@@ -289,11 +289,11 @@ st.
           currentLineNumber: 2,
           offset: 3,
         },
-        pyodide as PyodideInterface,
+        pyodide as PyodideInterface
       );
 
       expect(
-        autocompleteResults.items.map((item: { label: string }) => item.label),
+        autocompleteResults.items.map((item: { label: string }) => item.label)
       ).toEqual(
         expect.arrayContaining([
           "altair_chart",
@@ -304,7 +304,7 @@ st.
           "bar_chart",
           "bokeh_chart",
           "button",
-        ]),
+        ])
       );
     });
 
@@ -321,7 +321,7 @@ st.title()
           currentLineNumber: 3,
           offset: 9,
         },
-        pyodide as PyodideInterface,
+        pyodide as PyodideInterface
       );
 
       // the code editors use sortText to sort the items in the list
@@ -331,7 +331,7 @@ st.title()
         autocompleteResults.items
           .map((item: { sortText: string }) => item.sortText)
           .sort()
-          .slice(0, 3),
+          .slice(0, 3)
       ).toEqual(["aaanchor=", "aabody=", "aahelp="]);
     });
 
@@ -353,7 +353,7 @@ handle
           currentLineNumber: 8,
           offset: 6,
         },
-        pyodide as PyodideInterface,
+        pyodide as PyodideInterface
       );
 
       expect(
@@ -361,15 +361,15 @@ handle
           (item: { label: string; documentation: string }) => ({
             label: item.label,
             documentation: item.documentation.trim(),
-          }),
-        ),
+          })
+        )
       ).toEqual(
         expect.arrayContaining([
           {
             label: "handle",
             documentation: "This function returns the parameters as a string.",
           },
-        ]),
+        ])
       );
     });
 
@@ -385,13 +385,13 @@ handle
           currentLineNumber: 3,
           offset: 5,
         },
-        pyodide as PyodideInterface,
+        pyodide as PyodideInterface
       );
 
       expect(suggestions).toEqual(
         expect.objectContaining({
           items: [],
-        }),
+        })
       );
     });
 
@@ -405,15 +405,15 @@ handle
           code: code,
           currentLine: "'''",
           currentLineNumber: 1,
-          offset: 3,
+          offset: 1,
         },
-        pyodide as PyodideInterface,
+        pyodide as PyodideInterface
       );
 
       expect(suggestions).toEqual(
         expect.objectContaining({
           items: [],
-        }),
+        })
       );
     });
   },
@@ -423,5 +423,5 @@ handle
     // giving extra buffer time so that the test doesn't timeout
     // usually it takes way less time, max 7-8s
     timeout: 60 * 1000,
-  },
+  }
 );

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -312,7 +312,7 @@ st.
       // Should give function arguments suggestions
       const code = `import streamlit as st
 x = {}
-st.title() 
+st.title()
 `;
       const autocompleteResults = await getCodeCompletions(
         {

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -330,8 +330,9 @@ st.title()
       expect(
         autocompleteResults.items
           .map((item: { sortText: string }) => item.sortText)
-          .sort(),
-      ).toEqual(expect.arrayContaining(["aaanchor=", "aabody=", "aahelp="]));
+          .sort()
+          .slice(0, 3),
+      ).toEqual(["aaanchor=", "aabody=", "aahelp="]);
     });
 
     test("should give suggestions for local functions", async () => {

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -398,8 +398,6 @@ handle
     test("should handle invalid requests when the code contains string literals", async () => {
       const code = `'''`;
 
-      // This will throw an error and it should be handled and return an empty list
-      // SyntaxError: unterminated triple-quoted string literal (detected at line 92)
       const suggestions = await getCodeCompletions(
         {
           code: code,

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -30,6 +30,7 @@ interface InitializeWorkerEnvOptions {
   entrypoint: string;
   files: WorkerInitialData["files"];
   requirements?: WorkerInitialData["requirements"];
+  languageServer?: boolean;
 }
 async function initializeWorkerEnv(
   options: InitializeWorkerEnvOptions,
@@ -88,6 +89,7 @@ async function initializeWorkerEnv(
             requirements: options.requirements ?? [],
             moduleAutoLoad: false,
             prebuiltPackageNames: [],
+            languageServer: options.languageServer ?? false,
           },
         },
       }),
@@ -247,6 +249,7 @@ suite(
         files: {
           "chat.input.py": { data: content },
         },
+        languageServer: true,
       });
     });
     afterAll(() => {

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -258,15 +258,15 @@ suite(
 
     test("should give suggestions starting with word after the cursor", async () => {
       // Should give suggestions starting with word after the cursor
-      const code = `import math
-math.co
+      const code = `import streamlit as st
+st.te
 `;
       const autocompleteResults = await getCodeCompletions(
         {
           code: code,
-          currentLine: "math",
+          currentLine: "st.te",
           currentLineNumber: 2,
-          offset: 6,
+          offset: 5,
         },
         pyodide as PyodideInterface,
       );
@@ -274,20 +274,20 @@ math.co
       // Should give suggestions for the word after the comma
       expect(
         autocompleteResults.items.map((item: { label: string }) => item.label),
-      ).toEqual(expect.arrayContaining(["comb", "copysign", "cos", "cosh"]));
+      ).toEqual(expect.arrayContaining(["text", "text_area", "text_input"]));
     });
 
     test("should return suggestions for a module when no prefix after the cursor is present", async () => {
       // Should give suggestions for a module when no prefix is present
-      const code = `import math
-math.
+      const code = `import streamlit as st
+st.
 `;
       const autocompleteResults = await getCodeCompletions(
         {
           code: code,
-          currentLine: "math",
+          currentLine: "st.",
           currentLineNumber: 2,
-          offset: 5,
+          offset: 3,
         },
         pyodide as PyodideInterface,
       );
@@ -296,49 +296,42 @@ math.
         autocompleteResults.items.map((item: { label: string }) => item.label),
       ).toEqual(
         expect.arrayContaining([
-          "acos",
-          "acosh",
-          "asin",
-          "asinh",
-          "atan",
-          "atan2",
-          "ceil",
-          "comb",
+          "altair_chart",
+          "area_chart",
+          "audio",
+          "audio_input",
+          "balloons",
+          "bar_chart",
+          "bokeh_chart",
+          "button",
         ]),
       );
     });
 
-    test("should give function arguments suggestions", async () => {
+    test("should return and prioritize function arguments", async () => {
       // Should give function arguments suggestions
-      const code = `import json
+      const code = `import streamlit as st
 x = {}
-json.dumps(x, 
+st.title() 
 `;
       const autocompleteResults = await getCodeCompletions(
         {
           code: code,
-          currentLine: "json.dumps(x, ",
+          currentLine: "st.title()",
           currentLineNumber: 3,
-          offset: 13,
+          offset: 9,
         },
         pyodide as PyodideInterface,
       );
 
+      // the code editors use sortText to sort the items in the list
+      // before showing them on the UI
+      // function arguments have always bigger priority then other suggestions
       expect(
-        autocompleteResults.items.map((item: { label: string }) => item.label),
-      ).toEqual(
-        expect.arrayContaining([
-          "allow_nan=",
-          "check_circular=",
-          "cls=",
-          "default=",
-          "ensure_ascii=",
-          "indent=",
-          "separators=",
-          "skipkeys=",
-          "sort_keys=",
-        ]),
-      );
+        autocompleteResults.items
+          .map((item: { sortText: string }) => item.sortText)
+          .sort(),
+      ).toEqual(expect.arrayContaining(["aaanchor=", "aabody=", "aahelp="]));
     });
 
     test("should give suggestions for local functions", async () => {

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -266,7 +266,7 @@ st.te
           code: code,
           currentLine: "st.te",
           currentLineNumber: 2,
-          offset: 3,
+          offset: 5,
         },
         pyodide as PyodideInterface
       );
@@ -274,7 +274,32 @@ st.te
       // Should give suggestions for the word after the comma
       expect(
         autocompleteResults.items.map((item: { label: string }) => item.label)
-      ).toEqual(expect.arrayContaining(["text", "text_area", "text_input"]));
+      ).toEqual(["text", "text_area", "text_input"]);
+    });
+
+    test("should create correct text_edit range for the words after the cursor", async () => {
+      // Should give suggestions starting with word after the cursor
+      const code = `import streamlit as st
+st.te
+`;
+      const autocompleteResults = await getCodeCompletions(
+        {
+          code: code,
+          currentLine: "st.te",
+          currentLineNumber: 2,
+          offset: 3,
+        },
+        pyodide as PyodideInterface
+      );
+
+      const firstItem = autocompleteResults.items[0];
+      expect(firstItem.label).toEqual("altair_chart");
+      expect(firstItem.textEdit.range.start).toEqual(
+        expect.objectContaining({ line: 2, character: 3 })
+      );
+      expect(firstItem.textEdit.range.end).toEqual(
+        expect.objectContaining({ line: 2, character: 5 })
+      );
     });
 
     test("should return suggestions for a module when no prefix after the cursor is present", async () => {
@@ -293,19 +318,19 @@ st.
       );
 
       expect(
-        autocompleteResults.items.map((item: { label: string }) => item.label)
-      ).toEqual(
-        expect.arrayContaining([
-          "altair_chart",
-          "area_chart",
-          "audio",
-          "audio_input",
-          "balloons",
-          "bar_chart",
-          "bokeh_chart",
-          "button",
-        ])
-      );
+        autocompleteResults.items
+          .map((item: { label: string }) => item.label)
+          .slice(0, 8)
+      ).toEqual([
+        "altair_chart",
+        "area_chart",
+        "audio",
+        "audio_input",
+        "balloons",
+        "bar_chart",
+        "bokeh_chart",
+        "button",
+      ]);
     });
 
     test("should return and prioritize function arguments", async () => {
@@ -344,14 +369,14 @@ def handle(param_1: int, limit: str = "default") -> str:
   """
   return f"Result - param_1: {param_1}, limit: {limit}"
 
-handle
+hand
 `;
       const autocompleteResults = await getCodeCompletions(
         {
           code: code,
           currentLine: "handle",
           currentLineNumber: 8,
-          offset: 6,
+          offset: 4,
         },
         pyodide as PyodideInterface
       );
@@ -363,14 +388,12 @@ handle
             documentation: item.documentation.trim(),
           })
         )
-      ).toEqual(
-        expect.arrayContaining([
-          {
-            label: "handle",
-            documentation: "This function returns the parameters as a string.",
-          },
-        ])
-      );
+      ).toEqual([
+        {
+          label: "handle",
+          documentation: "This function returns the parameters as a string.",
+        },
+      ]);
     });
 
     test("should handle invalid requests and return empty response", async () => {

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -33,7 +33,7 @@ interface InitializeWorkerEnvOptions {
   languageServer?: boolean;
 }
 async function initializeWorkerEnv(
-  options: InitializeWorkerEnvOptions
+  options: InitializeWorkerEnvOptions,
 ): Promise<PyodideInterface> {
   const pyodideLoader: typeof import("./pyodide-loader") =
     await vitest.importActual("./pyodide-loader");
@@ -79,10 +79,10 @@ async function initializeWorkerEnv(
             entrypoint: options.entrypoint,
             wheels: {
               stliteLib: getWheelInstallPath(
-                stliteLibWheelUrl as unknown as string
+                stliteLibWheelUrl as unknown as string,
               ),
               streamlit: getWheelInstallPath(
-                streamlitWheelUrl as unknown as string
+                streamlitWheelUrl as unknown as string,
               ),
             },
             archives: [],
@@ -92,7 +92,7 @@ async function initializeWorkerEnv(
             languageServer: options.languageServer ?? false,
           },
         },
-      })
+      }),
     );
   });
 }
@@ -109,7 +109,7 @@ const TEST_SOURCES: {
     files: {
       "data.column_config.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/data.column_config.py"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/data.column_config.py",
       ),
     },
   },
@@ -118,7 +118,7 @@ const TEST_SOURCES: {
     files: {
       "chat.echo.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.echo.py"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.echo.py",
       ),
     },
   },
@@ -127,15 +127,15 @@ const TEST_SOURCES: {
     files: {
       "media.logo.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/media.logo.py"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/media.logo.py",
       ),
       "pages/images/horizontal_red.png": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/images/horizontal_red.png"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/images/horizontal_red.png",
       ),
       "pages/images/icon_red.png": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/images/icon_red.png"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/images/icon_red.png",
       ),
     },
   },
@@ -145,7 +145,7 @@ const TEST_SOURCES: {
     files: {
       "text.write_stream.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/text.write_stream.py"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/text.write_stream.py",
       ),
     },
     additionalAppTestCode: `
@@ -159,7 +159,7 @@ await at.run(timeout=20)
     files: {
       "layout.columns2.py": path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/layout.columns2.py"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/layout.columns2.py",
       ),
     },
   },
@@ -184,9 +184,9 @@ suite("Worker intergration test running an app", async () => {
               async ([filename, filepath]) => {
                 const content = await fsPromises.readFile(filepath);
                 return [filename, { data: content }];
-              }
-            )
-          )
+              },
+            ),
+          ),
         );
 
         const pyodide = await initializeWorkerEnv({
@@ -197,7 +197,7 @@ suite("Worker intergration test running an app", async () => {
 
         pyodide.globals.set(
           "__additionalAppTestCode__",
-          testSource.additionalAppTestCode
+          testSource.additionalAppTestCode,
         );
 
         // The code above setting up the worker env is good enough to check if the worker is set up correctly,
@@ -227,7 +227,7 @@ assert len(w) == 0, f"Warning occurred: {w[0].message if w else None}"
       },
       {
         timeout: 60 * 1000,
-      }
+      },
     );
   }
 });
@@ -240,7 +240,7 @@ suite(
       vitest.resetModules();
       const filePath = path.resolve(
         __dirname,
-        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py"
+        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py",
       );
       const content = await fsPromises.readFile(filePath);
 
@@ -268,12 +268,12 @@ st.te
           currentLineNumber: 2,
           offset: 5,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       // Should give suggestions for the word after the comma
       expect(
-        autocompleteResults.items.map((item: { label: string }) => item.label)
+        autocompleteResults.items.map((item: { label: string }) => item.label),
       ).toEqual(["text", "text_area", "text_input"]);
     });
 
@@ -289,16 +289,16 @@ st.te
           currentLineNumber: 2,
           offset: 3,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       const firstItem = autocompleteResults.items[0];
       expect(firstItem.label).toEqual("altair_chart");
       expect(firstItem.textEdit.range.start).toEqual(
-        expect.objectContaining({ line: 2, character: 3 })
+        expect.objectContaining({ line: 2, character: 3 }),
       );
       expect(firstItem.textEdit.range.end).toEqual(
-        expect.objectContaining({ line: 2, character: 5 })
+        expect.objectContaining({ line: 2, character: 5 }),
       );
     });
 
@@ -314,13 +314,13 @@ st.
           currentLineNumber: 2,
           offset: 3,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       expect(
         autocompleteResults.items
           .map((item: { label: string }) => item.label)
-          .slice(0, 8)
+          .slice(0, 8),
       ).toEqual([
         "altair_chart",
         "area_chart",
@@ -346,7 +346,7 @@ st.title()
           currentLineNumber: 3,
           offset: 9,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       // the code editors use sortText to sort the items in the list
@@ -356,7 +356,7 @@ st.title()
         autocompleteResults.items
           .map((item: { sortText: string }) => item.sortText)
           .sort()
-          .slice(0, 3)
+          .slice(0, 3),
       ).toEqual(["aaanchor=", "aabody=", "aahelp="]);
     });
 
@@ -378,7 +378,7 @@ hand
           currentLineNumber: 8,
           offset: 4,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       expect(
@@ -386,8 +386,8 @@ hand
           (item: { label: string; documentation: string }) => ({
             label: item.label,
             documentation: item.documentation.trim(),
-          })
-        )
+          }),
+        ),
       ).toEqual([
         {
           label: "handle",
@@ -398,7 +398,7 @@ hand
 
     test("should handle invalid requests and return empty response", async () => {
       const code = `import math
-      math.cos()
+math.cos()
       `;
 
       const suggestions = await getCodeCompletions(
@@ -408,13 +408,13 @@ hand
           currentLineNumber: 3,
           offset: 5,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       expect(suggestions).toEqual(
         expect.objectContaining({
           items: [],
-        })
+        }),
       );
     });
 
@@ -428,13 +428,13 @@ hand
           currentLineNumber: 1,
           offset: 1,
         },
-        pyodide as PyodideInterface
+        pyodide as PyodideInterface,
       );
 
       expect(suggestions).toEqual(
         expect.objectContaining({
           items: [],
-        })
+        }),
       );
     });
   },
@@ -444,5 +444,5 @@ hand
     // giving extra buffer time so that the test doesn't timeout
     // usually it takes way less time, max 7-8s
     timeout: 60 * 1000,
-  }
+  },
 );

--- a/packages/kernel/src/worker-runtime.test.ts
+++ b/packages/kernel/src/worker-runtime.test.ts
@@ -3,7 +3,16 @@ import path from "node:path";
 import type { PyodideInterface } from "pyodide";
 import stliteLibWheelUrl from "stlite_lib.whl"; // This is an alias configured in vitest.config.ts
 import streamlitWheelUrl from "streamlit.whl"; // This is an alias configured in vitest.config.ts
-import { afterEach, beforeEach, expect, suite, test, vitest } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  suite,
+  test,
+  vitest,
+} from "vitest";
 import { getCodeCompletions } from "./language-server/code_completion";
 import { WorkerInitialData } from "./types";
 import { type PostMessageFn } from "./worker-runtime";
@@ -221,138 +230,117 @@ assert len(w) == 0, f"Warning occurred: {w[0].message if w else None}"
   }
 });
 
-suite("Worker language server test", async () => {
-  beforeEach(() => {
-    vitest.resetModules();
-  });
-  afterEach(() => {
-    vitest.restoreAllMocks();
-  });
+suite(
+  "Worker language server test",
+  async () => {
+    let pyodide: PyodideInterface;
+    beforeAll(async () => {
+      vitest.resetModules();
+      const filePath = path.resolve(
+        __dirname,
+        "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py",
+      );
+      const content = await fsPromises.readFile(filePath);
 
-  test("should return suggestions", async () => {
-    const filePath = path.resolve(
-      __dirname,
-      "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py",
-    );
-    const content = await fsPromises.readFile(filePath);
-
-    const pyodide = await initializeWorkerEnv({
-      entrypoint: "chat.input.py",
-      files: {
-        "chat.input.py": { data: content },
-      },
+      pyodide = await initializeWorkerEnv({
+        entrypoint: "chat.input.py",
+        files: {
+          "chat.input.py": { data: content },
+        },
+      });
+    });
+    afterAll(() => {
+      vitest.restoreAllMocks();
     });
 
-    // Should give suggestions with items starting with word after the comma
-    let code = `import math
+    test("should give suggestions starting with word after the cursor", async () => {
+      // Should give suggestions starting with word after the cursor
+      const code = `import math
 math.co
 `;
-    let autocompleteResults = await getCodeCompletions(
-      {
-        code: code,
-        currentLine: "math",
-        currentLineNumber: 2,
-        offset: 6,
-      },
-      pyodide as PyodideInterface,
-    );
+      const autocompleteResults = await getCodeCompletions(
+        {
+          code: code,
+          currentLine: "math",
+          currentLineNumber: 2,
+          offset: 6,
+        },
+        pyodide as PyodideInterface,
+      );
 
-    // Should give suggestions for the word after the comma
-    expect(
-      autocompleteResults.items.map((item: { label: string }) => item.label),
-    ).toEqual(expect.arrayContaining(["comb", "copysign", "cos", "cosh"]));
+      // Should give suggestions for the word after the comma
+      expect(
+        autocompleteResults.items.map((item: { label: string }) => item.label),
+      ).toEqual(expect.arrayContaining(["comb", "copysign", "cos", "cosh"]));
+    });
 
-    // Should give suggestions for a module when no prefix is present
-    code = `import math
+    test("should return suggestions for a module when no prefix after the cursor is present", async () => {
+      // Should give suggestions for a module when no prefix is present
+      const code = `import math
 math.
 `;
-    autocompleteResults = await getCodeCompletions(
-      {
-        code: code,
-        currentLine: "math",
-        currentLineNumber: 2,
-        offset: 5,
-      },
-      pyodide as PyodideInterface,
-    );
+      const autocompleteResults = await getCodeCompletions(
+        {
+          code: code,
+          currentLine: "math",
+          currentLineNumber: 2,
+          offset: 5,
+        },
+        pyodide as PyodideInterface,
+      );
 
-    expect(
-      autocompleteResults.items.map((item: { label: string }) => item.label),
-    ).toEqual(
-      expect.arrayContaining([
-        "acos",
-        "acosh",
-        "asin",
-        "asinh",
-        "atan",
-        "atan2",
-        "ceil",
-        "comb",
-      ]),
-    );
+      expect(
+        autocompleteResults.items.map((item: { label: string }) => item.label),
+      ).toEqual(
+        expect.arrayContaining([
+          "acos",
+          "acosh",
+          "asin",
+          "asinh",
+          "atan",
+          "atan2",
+          "ceil",
+          "comb",
+        ]),
+      );
+    });
 
-    // Should give suggestions for a module when no prefix is present
-    code = `import math
-math.
-`;
-    autocompleteResults = await getCodeCompletions(
-      {
-        code: code,
-        currentLine: "math",
-        currentLineNumber: 2,
-        offset: 5,
-      },
-      pyodide as PyodideInterface,
-    );
-
-    expect(
-      autocompleteResults.items.map((item: { label: string }) => item.label),
-    ).toEqual(
-      expect.arrayContaining([
-        "acos",
-        "acosh",
-        "asin",
-        "asinh",
-        "atan",
-        "atan2",
-        "ceil",
-        "comb",
-      ]),
-    );
-
-    // Should give function arguments suggestions
-    code = `import json
+    test("should give function arguments suggestions", async () => {
+      // Should give function arguments suggestions
+      const code = `import json
 x = {}
 json.dumps(x, 
 `;
-    autocompleteResults = await getCodeCompletions(
-      {
-        code: code,
-        currentLine: "json.dumps(x, ",
-        currentLineNumber: 3,
-        offset: 13,
-      },
-      pyodide as PyodideInterface,
-    );
+      const autocompleteResults = await getCodeCompletions(
+        {
+          code: code,
+          currentLine: "json.dumps(x, ",
+          currentLineNumber: 3,
+          offset: 13,
+        },
+        pyodide as PyodideInterface,
+      );
 
-    expect(
-      autocompleteResults.items.map((item: { label: string }) => item.label),
-    ).toEqual(
-      expect.arrayContaining([
-        "allow_nan=",
-        "check_circular=",
-        "cls=",
-        "default=",
-        "ensure_ascii=",
-        "indent=",
-        "separators=",
-        "skipkeys=",
-        "sort_keys=",
-      ]),
-    );
+      expect(
+        autocompleteResults.items.map((item: { label: string }) => item.label),
+      ).toEqual(
+        expect.arrayContaining([
+          "allow_nan=",
+          "check_circular=",
+          "cls=",
+          "default=",
+          "ensure_ascii=",
+          "indent=",
+          "separators=",
+          "skipkeys=",
+          "sort_keys=",
+        ]),
+      );
+    });
 
-    // Should give suggestions for local functions
-    code = `import json
+    test("should give suggestions for local functions", async () => {
+      // Should give suggestions for local functions
+      const code = `import json
 def handle(param_1: int, limit: str = "default") -> str:
   """
   This function returns the parameters as a string.
@@ -361,65 +349,82 @@ def handle(param_1: int, limit: str = "default") -> str:
 
 handle
 `;
-    autocompleteResults = await getCodeCompletions(
-      {
-        code: code,
-        currentLine: "handle",
-        currentLineNumber: 8,
-        offset: 6,
-      },
-      pyodide as PyodideInterface,
-    );
-
-    expect(
-      autocompleteResults.items.map(
-        (item: { label: string; documentation: string }) => ({
-          label: item.label,
-          documentation: item.documentation.trim(),
-        }),
-      ),
-    ).toEqual(
-      expect.arrayContaining([
+      const autocompleteResults = await getCodeCompletions(
         {
-          label: "handle",
-          documentation: "This function returns the parameters as a string.",
+          code: code,
+          currentLine: "handle",
+          currentLineNumber: 8,
+          offset: 6,
         },
-      ]),
-    );
-  });
+        pyodide as PyodideInterface,
+      );
 
-  test("should handle invalid requests and return empty response", async () => {
-    const code = `import math
+      expect(
+        autocompleteResults.items.map(
+          (item: { label: string; documentation: string }) => ({
+            label: item.label,
+            documentation: item.documentation.trim(),
+          }),
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          {
+            label: "handle",
+            documentation: "This function returns the parameters as a string.",
+          },
+        ]),
+      );
+    });
+
+    test("should handle invalid requests and return empty response", async () => {
+      const code = `import math
       math.cos()
       `;
 
-    const filePath = path.resolve(
-      __dirname,
-      "../../sharing-editor/public/samples/011_component_gallery/pages/chat.input.py",
-    );
-    const content = await fsPromises.readFile(filePath);
+      const suggestions = await getCodeCompletions(
+        {
+          code: code,
+          currentLine: "math",
+          currentLineNumber: 3,
+          offset: 5,
+        },
+        pyodide as PyodideInterface,
+      );
 
-    const pyodide = await initializeWorkerEnv({
-      entrypoint: "chat.input.py",
-      files: {
-        "chat.input.py": { data: content },
-      },
+      expect(suggestions).toEqual(
+        expect.objectContaining({
+          items: [],
+        }),
+      );
     });
 
-    const suggestions = await getCodeCompletions(
-      {
-        code: code,
-        currentLine: "math",
-        currentLineNumber: 3,
-        offset: 5,
-      },
-      pyodide as PyodideInterface,
-    );
+    test("should handle invalid requests when the code contains string literals", async () => {
+      const code = `'''`;
 
-    expect(suggestions).toEqual(
-      expect.objectContaining({
-        items: [],
-      }),
-    );
-  });
-});
+      // This will throw an error and it should be handled and return an empty list
+      // SyntaxError: unterminated triple-quoted string literal (detected at line 92)
+      const suggestions = await getCodeCompletions(
+        {
+          code: code,
+          currentLine: "'''",
+          currentLineNumber: 1,
+          offset: 3,
+        },
+        pyodide as PyodideInterface,
+      );
+
+      expect(suggestions).toEqual(
+        expect.objectContaining({
+          items: [],
+        }),
+      );
+    });
+  },
+  {
+    // the tests take bit longer to execute
+    // because we are loading pyodide,files..etc.
+    // giving extra buffer time so that the test doesn't timeout
+    // usually it takes way less time, max 7-8s
+    timeout: 60 * 1000,
+  },
+);

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -108,6 +108,7 @@ export function startWorkerEnv(
       nodefsMountpoints,
       moduleAutoLoad,
       env,
+      languageServer,
     } = initData;
 
     const requirements = validateRequirements(unvalidatedRequirements); // Blocks the not allowed wheel URL schemes.
@@ -398,8 +399,10 @@ AppSession._on_scriptrunner_event = wrap_app_session_on_scriptrunner_event(AppSe
 
     const canonicalEntrypoint = resolveAppPath(appId, entrypoint);
 
-    postProgressMessage("Importing Language Server");
-    await importLanguageServerLibraries(pyodide, micropip);
+    if (languageServer) {
+      postProgressMessage("Importing Language Server");
+      await importLanguageServerLibraries(pyodide, micropip);
+    }
 
     postProgressMessage("Booting up the Streamlit server.");
     // The following Python code is based on streamlit.web.cli.main_run().

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -20,6 +20,8 @@ import type {
   ReplyMessage,
   PyodideConvertiblePrimitive,
 } from "./types";
+import { importLanguageServerLibraries } from "./language-server/language-server-loader";
+import { getCodeCompletions } from "./language-server/code_completion";
 
 export type PostMessageFn = (message: OutMessage, port?: MessagePort) => void;
 
@@ -396,6 +398,9 @@ AppSession._on_scriptrunner_event = wrap_app_session_on_scriptrunner_event(AppSe
 
     const canonicalEntrypoint = resolveAppPath(appId, entrypoint);
 
+    postProgressMessage("Importing Language Server");
+    await importLanguageServerLibraries(pyodide, micropip);
+
     postProgressMessage("Booting up the Streamlit server.");
     // The following Python code is based on streamlit.web.cli.main_run().
     console.debug("Setting up the Streamlit configuration");
@@ -656,6 +661,14 @@ prepare(main_script_path, args)
           console.debug("Successfully set the environment variables", env);
           reply({
             type: "reply",
+          });
+          break;
+        }
+        case "language-server:code_completion": {
+          const codeCompletions = await getCodeCompletions(msg.data, pyodide);
+          reply({
+            type: "reply:language-server:code_completion",
+            data: codeCompletions,
           });
           break;
         }


### PR DESCRIPTION
At Cognite, we've been using a fork of this repo to inject authentication token, configure startup settings, and implement a language server on top of the existing kernel.

We're hoping to move away from our fork and contribute our language server logic to the upstream repo.

This PR includes the very initial setup for the language server to work and keep the PR size small. I made the following changes:
* It installs `jedi` as a library when loading the kernel and added InMessage and ReplyMessage types
* Added a method in the Kernel for getting the code_completions
* Added a listener in the worker to listen and execute the python code that generates the suggestions
* I modified the worker-runtime test to test the code completion part. I did the changes there because the initialization code for pyodide and worker is there so I decided to re-use it

Next steps:
* Integrate the code_completions in the code editors (ex in the browser) - I need to look in the code where those changes should be made
* Add hover support
* Add diagnostics (validation) support
* Integrate in the vscode extension? 

I will work on integrating the code completions in the code editor and open another PR and merge both if that is preferred.

**How to test**
You can check the unit tests.
To test manually, call the getCodeCompletion method from kernel and pass/modify some of the payloads used in the tests. That is the request/response format that will be used with monaco editor.