### PR TITLE
feat: language server setup in the sharing application

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -342,7 +342,7 @@ export class StliteKernel {
 
   public getCodeCompletion(
     payload: LanguageServerRequestPayload,
-  ): Promise<ReplyMessageLanguageServerCodeCompletion> {
+  ): Promise<ReplyMessageLanguageServerCodeCompletion["data"]> {
     if (!this._workerInitData.languageServer) {
       throw new Error(
         `Language server not loaded, please set languageServer=true to use this method`,
@@ -354,7 +354,7 @@ export class StliteKernel {
         data: payload,
       },
       "reply:language-server:code_completion",
-    ).then((data) => ({ type: "reply:language-server:code_completion", data }));
+    );
   }
 
   /**

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -342,7 +342,7 @@ export class StliteKernel {
 
   public getCodeCompletion(
     payload: LanguageServerRequestPayload,
-  ): Promise<ReplyMessageLanguageServerCodeCompletion["data"]> {
+  ): Promise<ReplyMessageLanguageServerCodeCompletion> {
     if (!this._workerInitData.languageServer) {
       throw new Error(
         `Language server not loaded, please set languageServer=true to use this method`,
@@ -354,7 +354,7 @@ export class StliteKernel {
         data: payload,
       },
       "reply:language-server:code_completion",
-    ).then((data) => data);
+    ).then((data) => ({ type: "reply:language-server:code_completion", data }));
   }
 
   /**

--- a/packages/sharing-common/src/messages.ts
+++ b/packages/sharing-common/src/messages.ts
@@ -62,13 +62,35 @@ export type ForwardMessage =
 /**
  * Reply to a forward message.
  */
-export interface ReplyMessage {
-  type: "reply";
+export interface ReplyMessageBase {
+  type: string;
   /** Some reply messages can contain data ex: code_completion, read_file
    */
-  data?: ForwardMessage;
+  data?: unknown;
   error?: Error;
 }
+
+export interface GeneralReplyMessage extends ReplyMessageBase {
+  type: "reply";
+}
+export interface LanguageServerCodeCompletionResponse {
+  /**
+   * Decided to use unknown to avoid importing whole package and bunch of stuff
+   * from monaco-editor package that we don't need it here at all
+   * https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.CompletionItem.html
+   *
+   */
+  items: unknown[];
+}
+export interface LanguageServerCodeCompletionReplyMessage
+  extends ReplyMessageBase {
+  type: "reply:language-server:code_completion";
+  data: LanguageServerCodeCompletionResponse;
+}
+
+export type ReplyMessage =
+  | GeneralReplyMessage
+  | LanguageServerCodeCompletionReplyMessage;
 
 /**
  * Messages from app to editor

--- a/packages/sharing-common/src/messages.ts
+++ b/packages/sharing-common/src/messages.ts
@@ -39,18 +39,34 @@ export interface InstallMessage extends ForwardMessageBase {
     requirements: string[];
   };
 }
+
+export interface LanguageServerCodeCompletionMessage
+  extends ForwardMessageBase {
+  type: "language-server:code_completion";
+  data: {
+    code: string;
+    currentLine: string;
+    currentLineNumber: number;
+    offset: number;
+  };
+}
+
 export type ForwardMessage =
   | RebootMessage
   | FileWriteMessage
   | FileRenameMessage
   | FileUnlinkMessage
-  | InstallMessage;
+  | InstallMessage
+  | LanguageServerCodeCompletionMessage;
 
 /**
  * Reply to a forward message.
  */
 export interface ReplyMessage {
   type: "reply";
+  /** Some reply messages can contain data ex: code_completion, read_file
+   */
+  data?: ForwardMessage;
   error?: Error;
 }
 

--- a/packages/sharing-common/src/proto/models.proto
+++ b/packages/sharing-common/src/proto/models.proto
@@ -4,7 +4,6 @@ message AppData {
   string entrypoint = 1;
   map<string, File> files = 2;
   repeated string requirements = 3;
-  optional bool languageServer = 4;
 }
 
 message File {

--- a/packages/sharing-common/src/proto/models.proto
+++ b/packages/sharing-common/src/proto/models.proto
@@ -4,6 +4,7 @@ message AppData {
   string entrypoint = 1;
   map<string, File> files = 2;
   repeated string requirements = 3;
+  optional bool languageServer = 4;
 }
 
 message File {

--- a/packages/sharing-common/src/url.spec.ts
+++ b/packages/sharing-common/src/url.spec.ts
@@ -104,7 +104,7 @@ describe("Process share URL", () => {
 
   it("Should correctly extract App Data from URL", async () => {
     const urlHash =
-      "#!ChBzdHJlYW1saXRfYXBwLnB5EkcKEHN0cmVhbWxpdF9hcHAucHkSMwoxaW1wb3J0IHN0cmVhbWxpdCBhcyBzdAoKc3QudGl0bGUoIkhlbGxvIFdvcmxkISIpCiAB";
+      "#!ChBzdHJlYW1saXRfYXBwLnB5Em4KEHN0cmVhbWxpdF9hcHAucHkSWgpYaW1wb3J0IHN0cmVhbWxpdCBhcyBzdAoKc3QudGl0bGUoIkhlbGxvIFdvcmxkISIpCnN0LmJ1dHRvbihsYWJlbD0iVGVzdCIsIHR5cGU9InByaW1hcnkiKQ,=";
     Object.defineProperty(window, "location", {
       writable: true,
       value: {
@@ -125,12 +125,11 @@ describe("Process share URL", () => {
           "streamlit_app.py": {
             content: {
               $case: "text",
-              text: 'import streamlit as st\n\nst.title("Hello World!")\n',
+              text: 'import streamlit as st\n\nst.title("Hello World!")\nst.button(label="Test", type="primary")',
             },
           },
         },
         requirements: [],
-        languageServer: true,
       }),
     );
   });

--- a/packages/sharing-common/src/url.spec.ts
+++ b/packages/sharing-common/src/url.spec.ts
@@ -102,7 +102,7 @@ describe("parseHash", () => {
 describe("Process share URL", () => {
   global.window ??= Object.create(window);
 
-  it("Should correctly recognize app url name from URL", async () => {
+  it("Should correctly extract App Data from URL", async () => {
     const urlHash =
       "#!ChBzdHJlYW1saXRfYXBwLnB5EkcKEHN0cmVhbWxpdF9hcHAucHkSMwoxaW1wb3J0IHN0cmVhbWxpdCBhcyBzdAoKc3QudGl0bGUoIkhlbGxvIFdvcmxkISIpCiAB";
     Object.defineProperty(window, "location", {
@@ -116,6 +116,7 @@ describe("Process share URL", () => {
       },
     });
 
+    // Check if languageServer can be extracted as well
     const parsedParams = await extractAppDataFromUrl();
     expect(parsedParams).toEqual(
       expect.objectContaining({

--- a/packages/sharing-editor/src/StliteSharingIFrame/index.tsx
+++ b/packages/sharing-editor/src/StliteSharingIFrame/index.tsx
@@ -40,6 +40,7 @@ const StliteSharingIFrame = React.forwardRef<
     const iframeSrc = useMemo(
       () => {
         const urlParams = new URLSearchParams();
+        urlParams.append("languageServer", "true");
         urlParams.append("embed", "true");
         urlParams.append("embed_options", "show_toolbar");
         if (theme) {

--- a/packages/sharing/src/App.tsx
+++ b/packages/sharing/src/App.tsx
@@ -8,7 +8,7 @@ import {
   ModuleAutoLoadSuccessMessage,
 } from "@stlite/sharing-common";
 import StreamlitApp from "./StreamlitApp";
-import { isSharedWorkerMode } from "./urlparams";
+import { isLanguageServerEnabled, isSharedWorkerMode } from "./urlparams";
 import {
   makeToastKernelCallbacks,
   StliteKernelWithToast,
@@ -102,7 +102,7 @@ st.write("Hello World")`,
           prebuiltPackageNames: [],
           ...makeToastKernelCallbacks(),
           moduleAutoLoad: true,
-          languageServer: appData.languageServer ?? false,
+          languageServer: isLanguageServerEnabled(),
           sharedWorker: isSharedWorkerMode(),
           wheelUrls,
           workerType: "module", // Vite loads the worker scripts as ES modules without bundling at dev time, so we need to specify the type as "module" for the "import" statements in the worker script to work.

--- a/packages/sharing/src/App.tsx
+++ b/packages/sharing/src/App.tsx
@@ -42,7 +42,7 @@ function isEditorOrigin(origin: string): boolean {
 let communicatedEditorOrigin = "";
 
 function convertFiles(
-  appDataFiles: AppData["files"],
+  appDataFiles: AppData["files"]
 ): StliteKernelOptions["files"] {
   const files: StliteKernelOptions["files"] = {};
   Object.keys(appDataFiles).forEach((key) => {
@@ -102,6 +102,7 @@ st.write("Hello World")`,
           prebuiltPackageNames: [],
           ...makeToastKernelCallbacks(),
           moduleAutoLoad: true,
+          languageServer: appData.languageServer ?? false,
           sharedWorker: isSharedWorkerMode(),
           wheelUrls,
           workerType: "module", // Vite loads the worker scripts as ES modules without bundling at dev time, so we need to specify the type as "module" for the "import" statements in the worker script to work.
@@ -124,7 +125,7 @@ st.write("Hello World")`,
                     },
                     stlite: true,
                   } as ModuleAutoLoadSuccessMessage,
-                  EDITOR_APP_ORIGIN ?? communicatedEditorOrigin, // Fall back to the origin of the last message from the editor app if the EDITOR_APP_ORIGIN is not set, i.e. in preview deployments.
+                  EDITOR_APP_ORIGIN ?? communicatedEditorOrigin // Fall back to the origin of the last message from the editor app if the EDITOR_APP_ORIGIN is not set, i.e. in preview deployments.
                 );
               })
               .catch((error) => {
@@ -157,13 +158,13 @@ st.write("Hello World")`,
               case "file:write": {
                 return kernelWithToast.writeFile(
                   msg.data.path,
-                  msg.data.content,
+                  msg.data.content
                 );
               }
               case "file:rename": {
                 return kernelWithToast.renameFile(
                   msg.data.oldPath,
-                  msg.data.newPath,
+                  msg.data.newPath
                 );
               }
               case "file:unlink": {

--- a/packages/sharing/src/urlparams.ts
+++ b/packages/sharing/src/urlparams.ts
@@ -2,3 +2,8 @@ export function isSharedWorkerMode(): boolean {
   const params = new URLSearchParams(window.location.search);
   return params.has("sharedWorker");
 }
+
+export function isLanguageServerEnabled(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  return params.has("languageServer");
+}


### PR DESCRIPTION
Updating the code in the sharing app to:
- Decode the URL and pass the languageServer option to the Kernel
- Listen for messages returned from the worker for code_complete and forward the data to sharing-editor

# How to test
1. Build `kernel` and `sharing-common`
2. Start sharing app - `EDITOR_APP_ORIGIN="http://localhost:5173" yarn start`
3. Open an app with the sharing URL that inclides the languageServer field. You can use [this one](http://localhost:3000/#!ChBzdHJlYW1saXRfYXBwLnB5EkcKEHN0cmVhbWxpdF9hcHAucHkSMwoxaW1wb3J0IHN0cmVhbWxpdCBhcyBzdAoKc3QudGl0bGUoIkhlbGxvIFdvcmxkISIpCiAB) as an example
4. If everything is ok, you will see a toast message being displayed saying "Importing Language Server"

If you want to test the autocomplete, run the `sharing-editor` app and open the browser console and paste the code bellow. This will simulate the communication that needs to happen from sharing-editor app (from monaco editor):
```JS

sendMessage({ type: 'language-server:code_completion', data: { code: 'import math\nmath.', currentLine: 'math.', currentLineNumber: 2, offset: 5} }).then((res) => console.log(res))

var sendMessage = (message, messageTargetOrigin) => {

    
    return new Promise((resolve, reject) => {
      const targetWindow = document.querySelector('.preview-iframe').contentWindow;
      if (targetWindow == null) {
        throw new Error(`The target iframe window is not ready`);
      }

      const channel = new MessageChannel();

      channel.port1.onmessage = (e) => {
          console.log('response received from iframe', e);
        channel.port1.close();
        const reply = e.data;
        if (reply.error) {
          reject(reply.error);
        } else {
          resolve();
        }
      };

      targetWindow.postMessage(message, "http://localhost:3000", [
        channel.port2,
      ]);
    });
  
}
```

