### PR TITLE
Fix EDITOR_APP_ORIGIN_REGEX and EDITOR_APP_ORIGIN settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -413,7 +413,7 @@ jobs:
     ## Build and upload @stlite/sharing
     - name: Set EDITOR_APP_ORIGIN (preview)
       if: github.ref_name != github.event.repository.default_branch
-      run: echo "EDITOR_APP_ORIGIN_REGEX=^https://[a-z0-9]+\.stlite-sharing-editor\.pages\.dev$" >> $GITHUB_ENV
+      run: echo "EDITOR_APP_ORIGIN_REGEX=^https://[a-z0-9-]+\.stlite-sharing-editor\.pages\.dev$" >> $GITHUB_ENV
     - name: Set EDITOR_APP_ORIGIN (main branch)
       if: github.ref_name == github.event.repository.default_branch
       run: echo "EDITOR_APP_ORIGIN=https://edit.share.stlite.net" >> $GITHUB_ENV

--- a/packages/sharing/package.json
+++ b/packages/sharing/package.json
@@ -21,7 +21,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "start": "cross-env EDITOR_APP_ORIGIN=${EDITOR_APP_ORIGIN:=http://localhost:3030} vite",
+    "start": "cross-env EDITOR_APP_ORIGIN=${EDITOR_APP_ORIGIN:=http://localhost:5173} vite",
     "build": "vite build",
     "fix:eslint": "eslint --fix 'src/**/*.{ts,tsx}'",
     "fix:prettier": "prettier --write .",


### PR DESCRIPTION
* `EDITOR_APP_ORIGIN_REGEX`: because we started using `pages-deployment-alias-url` rather than `deployment-url` since #1346, the regex had been invalid.
* `EDITOR_APP_ORIGIN` value for local dev had bee invalid since we switched to Vite.