### PR TITLE
Fix `@stlite/browser` to set the good default values to `workerType` and `wheelUrls`

### DIFF
--- a/packages/browser/src/mount.tsx
+++ b/packages/browser/src/mount.tsx
@@ -31,9 +31,9 @@ export function mount(
 ) {
   const { kernelOptions, toastCallbackOptions } = parseMountOptions(options);
   const kernel = new StliteKernel({
-    wheelUrls,
-    workerType,
     ...kernelOptions,
+    wheelUrls: kernelOptions.wheelUrls ?? wheelUrls,
+    workerType: kernelOptions.workerType ?? workerType,
     ...makeToastKernelCallbacks(toastCallbackOptions),
   });
 


### PR DESCRIPTION
To fix a bug introduced in #1388