### PR TITLE
Fix the order of exports fields in @stlite/browser

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -24,8 +24,8 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./build/stlite.js",
-        "types": "./build/stlite.d.ts"
+        "types": "./build/stlite.d.ts",
+        "default": "./build/stlite.js"
       }
     },
     "./wheels/*.whl": "./build/wheels/*.whl"


### PR DESCRIPTION
Fixes the following warning.
```
▲ [WARNING] The condition "types" here will never be used as it comes after "default" [package.json]

    package.json:28:8:
      28 │         "types": "./build/stlite.d.ts"
         ╵         ~~~~~~~

  The "default" condition comes earlier and will always be chosen:

    package.json:27:8:
      27 │         "default": "./build/stlite.js",
         ╵         ~~~~~~~~~
```