### PR TITLE
Revert "Modify .github/workflows/test-build.yml to use the attest action integrated with the upload action (#1531)"

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -394,16 +394,15 @@ jobs:
       run: yarn pack
 
     - name: Upload the built tar ball as an artifact
-      id: upload
       uses: actions/upload-artifact@v4
       with:
         path: packages/browser/package.tgz
         name: stlite-browser
 
-    - uses: actions/attest-build-provenance@v2
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
       with:
-        subject-name: stlite-browser
-        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
+        subject-path: packages/browser/package.tgz
       # This step may fail when the PR is created by an external contributor and the CI is run in their scope.
       # We can ignore such failures because the following jobs such as E2E-testing in the post-build workflow don't necessarily need the attestation,
       # while the verification is done when publishing the artifact.
@@ -560,15 +559,14 @@ jobs:
 
     - name: Upload the built tar ball as an artifact
       uses: actions/upload-artifact@v4
-      id: upload
       with:
         path: packages/desktop/package.tgz
         name: stlite-desktop
 
-    - uses: actions/attest-build-provenance@v2
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
       with:
-        subject-name: stlite-desktop
-        subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
+        subject-path: packages/desktop/package.tgz
       # This step may fail when the PR is created by an external contributor and the CI is run in their scope.
       # We can ignore such failures because the following jobs such as E2E-testing in the post-build workflow don't necessarily need the attestation,
       # while the verification is done when publishing the artifact.


### PR DESCRIPTION
What #1531 does is to generate a provenance for the archive created by `actions/upload-artifacts`.
However, what we want is the provenance for artifact itself, i.e. `package.tgz`.
This mismatch leads to failure of attestation verification in the post-build pipeline: https://github.com/whitphx/stlite/actions/runs/16248380822/job/45874548260