### PR TITLE
fix: update deprecated GitHub Actions artifact versions from v3 to v4

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,3 +9,4 @@ changelog:
     - title: 👒 Dependencies
       labels:
         - dependencies
+


### PR DESCRIPTION
# Ignore this