### PR TITLE
Make @stlite/common-react and @stlite/sharing-common ESM

### DIFF
--- a/packages/common-react/package.json
+++ b/packages/common-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stlite/common-react",
   "version": "0.89.1",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/sharing-common/package.json
+++ b/packages/sharing-common/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@stlite/sharing-common",
   "version": "0.89.1",
+  "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module configuration for common-react and sharing-common packages to use ES modules.
  * Updated type declarations reference in sharing-common package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->