### PR TITLE
Update node_modules make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(venv): .python-version requirements.dev.txt streamlit/lib/dev-requirements.txt
 
 .PHONY: node_modules
 node_modules: $(node_modules)
-$(node_modules): package.json $(shell find packages/ -type f -name "package.json" -maxdepth 2) $(shell find streamlit/frontend/ -type f -name "package.json" -maxdepth 2) ./yarn.lock
+$(node_modules): package.json $(shell find packages/ -maxdepth 2 -type f -name "package.json") $(shell find streamlit/frontend/ -maxdepth 2 -type f -name "package.json") ./yarn.lock
 	yarn install
 	@mkdir -p $(dir $@)
 	@touch $@


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build dependency tracking so package install steps are retriggered when any nested package manifest changes, not just the top-level manifest. This yields more accurate and timely rebuilds of development dependencies, reducing stale installs and helping local and CI builds stay in sync with changes across project packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->