### PR TITLE
Use yarn install --immutable in CI env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,14 +81,18 @@ $(venv): .python-version requirements.dev.txt streamlit/lib/dev-requirements.txt
 	@touch $@
 	@echo "\nPython virtualenv has been set up. Run the command below to activate.\n\n. $(VENV_PATH)/bin/activate"
 
+CI ?= false
+
+ifeq ($(CI), true)
+	YARN_INSTALL_FLAGS := --immutable
+else
+	YARN_INSTALL_FLAGS :=
+endif
+
 .PHONY: node_modules
 node_modules: $(node_modules)
 $(node_modules): package.json $(shell find packages/ -maxdepth 2 -type f -name "package.json") $(shell find streamlit/frontend/ -maxdepth 2 -type f -name "package.json") ./yarn.lock
-	if [ -n "$${CI:-}" ]; then \
-		yarn install --immutable; \
-	else \
-		yarn install; \
-	fi
+	yarn install $(YARN_INSTALL_FLAGS)
 	@mkdir -p $(dir $@)
 	@touch $@
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made dependency installation conditional for CI environments so installs use a stricter, CI-appropriate mode when running in CI and standard mode otherwise, resulting in more consistent and reliable build artifacts and faster failure detection during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->