### PR TITLE
Use wildcard to specify frontend workspaces in streamlit/frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "stlite",
   "workspaces": [
     "packages/*",
+    "streamlit/frontend",
     "streamlit/frontend/*",
     "packages/desktop/samples/*"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9847,7 +9847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:^9.1.2":
+"concurrently@npm:^9.1.2, concurrently@npm:^9.2.1":
   version: 9.2.1
   resolution: "concurrently@npm:9.2.1"
   dependencies:
@@ -15808,7 +15808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.4.2":
+"jiti@npm:^2.4.2, jiti@npm:^2.5.1":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
   bin:
@@ -21865,6 +21865,17 @@ __metadata:
   checksum: 10c0/939cd1051ca750d240a0625b106a2b988c45fb5a3be0cebe9a9858cb01bc1955e8c7b9fac17a9462976bea4a7b704e317c5c2200c70f0ca715a3363b9aa4fd3b
   languageName: node
   linkType: hard
+
+"streamlit@workspace:streamlit/frontend":
+  version: 0.0.0-use.local
+  resolution: "streamlit@workspace:streamlit/frontend"
+  dependencies:
+    "@vitest/coverage-v8": "npm:^3.2.4"
+    concurrently: "npm:^9.2.1"
+    jiti: "npm:^2.5.1"
+    vitest: "npm:^3.2.4"
+  languageName: unknown
+  linkType: soft
 
 "streamx@npm:^2.15.0":
   version: 2.23.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated frontend workspace entries into a single wildcard entry, broadening which frontend packages are included without changing scripts, dependencies, or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->