### PR TITLE
Update eslint-plugin-react-hooks to 7

### DIFF
--- a/packages/browser/eslint.config.mjs
+++ b/packages/browser/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
   tseslint.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
     settings: {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,7 +53,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "prettier": "^3.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/common-react/eslint.config.mjs
+++ b/packages/common-react/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
   tseslint.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
     settings: {

--- a/packages/common-react/package.json
+++ b/packages/common-react/package.json
@@ -24,7 +24,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "prettier": "^3.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/desktop/eslint.config.mjs
+++ b/packages/desktop/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
   tseslint.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
     settings: {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -81,7 +81,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "glob": "^11.0.1",
     "node-html-parser": "^7.0.1",
     "prettier": "^3.6.2",

--- a/packages/kernel/eslint.config.mjs
+++ b/packages/kernel/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
   tseslint.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
     settings: {

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -31,7 +31,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "prettier": "^3.6.2",
     "pyodide": "0.28.2",
     "typescript": "^5.9.2",

--- a/packages/sharing-editor/eslint.config.mjs
+++ b/packages/sharing-editor/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
   tseslint.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
     settings: {

--- a/packages/sharing-editor/package.json
+++ b/packages/sharing-editor/package.json
@@ -52,7 +52,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^20.0.3",
     "npm-run-all2": "^8.0.4",
     "prettier": "^3.6.2",

--- a/packages/sharing/eslint.config.mjs
+++ b/packages/sharing/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
   tseslint.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
     settings: {

--- a/packages/sharing/package.json
+++ b/packages/sharing/package.json
@@ -23,7 +23,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "prettier": "^3.6.2",
     "sass": "^1.90.0",
     "typescript": "^5.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4763,7 +4763,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     eslint-plugin-prettier: "npm:^5.5.3"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.0.0-rc.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     prettier: "npm:^3.6.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -4788,7 +4788,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     eslint-plugin-prettier: "npm:^5.5.3"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.0.0-rc.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     prettier: "npm:^3.6.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -4837,7 +4837,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     eslint-plugin-prettier: "npm:^5.5.3"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.0.0-rc.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^11.0.1"
     node-html-parser: "npm:^7.0.1"
@@ -4888,7 +4888,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     eslint-plugin-prettier: "npm:^5.5.3"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.0.0-rc.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     path-browserify: "npm:^1.0.1"
     prettier: "npm:^3.6.2"
     pyodide: "npm:0.28.2"
@@ -4935,7 +4935,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     eslint-plugin-prettier: "npm:^5.5.3"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.0.0-rc.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     jsdom: "npm:^20.0.3"
     mime: "npm:^4.0.1"
     monaco-editor: "npm:^0.52.2"
@@ -4978,7 +4978,7 @@ __metadata:
     eslint: "npm:^9.32.0"
     eslint-plugin-prettier: "npm:^5.5.3"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^6.0.0-rc.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
     prettier: "npm:^3.6.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -12756,7 +12756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^6.0.0-rc.1, eslint-plugin-react-hooks@npm:^6.0.0-rc.2":
+"eslint-plugin-react-hooks@npm:^6.0.0-rc.2":
   version: 6.1.1
   resolution: "eslint-plugin-react-hooks@npm:6.1.1"
   dependencies:
@@ -12767,6 +12767,21 @@ __metadata:
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
   checksum: 10c0/579be053bc89c995a6c03996f9ee3f6bac88946b4b1c8b891b42f981e7c05a9c5de46324bbd2a33199855c0a602820c0e3eeb7f840730301b77a9ba3dc7a0ae2
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-react-hooks@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "eslint-plugin-react-hooks@npm:7.0.1"
+  dependencies:
+    "@babel/core": "npm:^7.24.4"
+    "@babel/parser": "npm:^7.24.4"
+    hermes-parser: "npm:^0.25.1"
+    zod: "npm:^3.25.0 || ^4.0.0"
+    zod-validation-error: "npm:^3.5.0 || ^4.0.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+  checksum: 10c0/1e711d1a9d1fa9cfc51fa1572500656577201199c70c795c6a27adfc1df39e5c598f69aab6aa91117753d23cc1f11388579a2bed14921cf9a4efe60ae8618496
   languageName: node
   linkType: hard
 
@@ -14713,6 +14728,22 @@ __metadata:
   bin:
     he: bin/he
   checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 10c0/48be3b2fa37a0cbc77a112a89096fa212f25d06de92781b163d67853d210a8a5c3784fac23d7d48335058f7ed283115c87b4332c2a2abaaccc76d0ead1a282ac
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: "npm:0.25.1"
+  checksum: 10c0/3abaa4c6f1bcc25273f267297a89a4904963ea29af19b8e4f6eabe04f1c2c7e9abd7bfc4730ddb1d58f2ea04b6fee74053d8bddb5656ec6ebf6c79cc8d14202c
   languageName: node
   linkType: hard
 
@@ -25216,7 +25247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-validation-error@npm:^3.0.3 || ^4.0.0":
+"zod-validation-error@npm:^3.0.3 || ^4.0.0, zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
   peerDependencies:
@@ -25225,7 +25256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.4 || ^4.0.0, zod@npm:^4.1.5":
+"zod@npm:^3.22.4 || ^4.0.0, zod@npm:^3.25.0 || ^4.0.0, zod@npm:^4.1.5":
   version: 4.1.12
   resolution: "zod@npm:4.1.12"
   checksum: 10c0/b64c1feb19e99d77075261eaf613e0b2be4dfcd3551eff65ad8b4f2a079b61e379854d066f7d447491fcf193f45babd8095551a9d47973d30b46b6d8e2c46774


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded React Hooks linting plugin from release candidate to stable version (7.x) across all packages.
  * Updated linting configuration to use standardized recommended settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->