### PR TITLE
Add build config files to the dependency lists in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ $(GIT_SUBMODULES): %/.git: .gitmodules
 common: $(common)
 $(common): $(shell \
 	find packages/common/src -type f -name "*.ts"; \
-	find packages/common -maxdepth 1 -type f \( -name "package.json" -o -name "tsconfig*.json" -o -name "vite.config.ts" \); \
+	find packages/common -maxdepth 1 -type f \( -name "package.json" -o -name "tsconfig*.json" \); \
 ) $(node_modules)
 	cd packages/common && yarn build
 	@mkdir -p $(dir $@)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened build dependency scanning to include top-level configuration and metadata files across multiple packages, alongside source files, so configuration changes reliably trigger rebuilds while preserving existing build behavior and outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->