### PR TITLE
tweak the if-condition on notify-browser-preview-deployments job beca…

### DIFF
--- a/.github/workflows/postbuild.yml
+++ b/.github/workflows/postbuild.yml
@@ -453,7 +453,8 @@ jobs:
   # We need to introduce an incremental comment update mechanism to unify them.
   notify-browser-preview-deployments:
     needs: [get-build-info, deploy-browser-preview]
-    if: ${{ needs.get-build-info.outputs.pr-number != '' && failure() }}
+    if: ${{ needs.get-build-info.outputs.pr-number != '' && always() }}
+    # always() is needed to notify even if e2e tests have failed.
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
…use it wasn't triggered when the e2e test failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted deployment notification behavior so browser preview deployment notifications are sent reliably even when prior steps fail, ensuring you get alerts for preview deployments (including failure cases).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->