### PR TITLE
Sync requirements editor when parsing uploads

### DIFF
--- a/packages/sharing-editor/src/Editor/index.tsx
+++ b/packages/sharing-editor/src/Editor/index.tsx
@@ -234,6 +234,10 @@ const Editor = React.forwardRef<EditorRef, EditorProps>(
         return;
       }
 
+      // Keep the Monaco model for `requirements` in sync with the latest parsed
+      // text while the tab is selected. We rely on the model so that imperative
+      // updates from `addRequirements` append to the most recent content rather
+      // than a stale default value.
       const uri = monaco.Uri.parse(REQUIREMENTS_FILENAME);
       const model =
         monaco.editor.getModel(uri) ??


### PR DESCRIPTION
#1100

## Summary
- ensure the requirements editor model stays in sync when switching to the requirements tab
- populate the requirements tab content after parsing uploaded requirements files

## Testing
- yarn workspace @stlite/sharing-editor test *(fails: missing node_modules state file)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692feba4cfd0832a91a6d3e788f1dc8c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and handling of uploaded requirements files with seamless integration into the editor workspace.

* **Improvements**
  * Requirements tab now initializes and syncs editor content to the app’s default requirements text when selected, ensuring consistent content after uploads or tab switches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->