### PR TITLE
Simplify inform-package-stats action to require pr-number

### DIFF
--- a/.github/actions/inform-package-stats/action.yml
+++ b/.github/actions/inform-package-stats/action.yml
@@ -2,8 +2,8 @@ name: Inform package stats
 description: "Post comment to a pull request page about package stats"
 inputs:
   pr-number:
-    required: false
-    description: "The PR number to inform. If not provided, the action will infer the PR number from the event type."
+    required: true
+    description: "The PR number to inform."
   stats-file-prefix:
     default: "package-stats."
     description: stats file name prefix
@@ -183,12 +183,10 @@ runs:
 
           fs.writeFileSync('comment.txt', comment);
 
-    - name: Post a message to Pull Request threads
+    - name: Post a message to Pull Request thread
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         PR_NUMBER: ${{ inputs.pr-number }}
-        COMMIT_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        # When the event is `pull_request`, `github.sha` points to a temporary merge commit, so we use `github.event.pull_request.head.sha` instead. Ref: https://github.com/orgs/community/discussions/47804#discussioncomment-5026092
       with:
         script: |
           process.chdir(process.env.PACKAGE_STATS_WORKING_DIR);
@@ -197,74 +195,46 @@ runs:
 
           const commentBody = fs.readFileSync('comment.txt');
 
-          async function getTargetPullRequests() {
-            if (process.env.PR_NUMBER) {
-              return [
-                (await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: process.env.PR_NUMBER,
-                })).data
-              ];
+          const prNumber = Number(process.env.PR_NUMBER);
+          const pr = (await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+          })).data;
+          const commitSha = pr.head.sha;
+
+          const stickyCommentHeader = `<!-- Sticky Stat Comment ${commitSha} -->\n`;
+          const title = `## Package Stats on [\`${commitSha.slice(0, 7)}\`](${pr.html_url}/commits/${commitSha})\n\n`;
+          const commentText = title + commentBody;
+          const stickyCommentText = stickyCommentHeader + commentText;
+
+          const existingComments = await github.paginate(
+            github.rest.issues.listComments,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
             }
-            if (context.eventName === "pull_request") {
-              return [context.payload.pull_request];
-            }
-            if (context.eventName === "push" || context.eventName === "workflow_run") {
-              const pullRequests = (
-                await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  commit_sha: process.env.COMMIT_SHA,
-                })
-              ).data;
-              const openPullRequests = pullRequests.filter(pr => pr.state === "open")
-              return openPullRequests;
-            }
-            throw new Error(`Unsupported event type: ${context.eventName}`);
-          }
-          const targetPullRequests = await getTargetPullRequests();
+          );
 
-          core.startGroup('Found PRs:')
-          console.log(targetPullRequests)
-          core.endGroup()
+          const existingComment = existingComments.find(comment =>
+            comment.body.startsWith(stickyCommentHeader) && comment.user.login === 'github-actions[bot]'
+          );
 
-          const stickyCommentHeader = `<!-- Sticky Stat Comment ${process.env.COMMIT_SHA} -->\n`;
-
-          for (const pr of targetPullRequests) {
-            const title = `## Package Stats on [\`${process.env.COMMIT_SHA.slice(0, 7)}\`](${pr.html_url}/commits/${process.env.COMMIT_SHA})\n\n`;
-            const commentText = title + commentBody;
-
-            const stickyCommentText = stickyCommentHeader + commentText
-
-            const existingComments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-              }
-            );
-
-            const existingComment = existingComments.find(comment =>
-              comment.body.startsWith(stickyCommentHeader) && comment.user.login === 'github-actions[bot]'
-            );
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body: stickyCommentText,
-              });
-              core.info(`Updated comment on PR #${pr.number}`);
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: stickyCommentText,
-              });
-              core.info(`Created comment on PR #${pr.number}`);
-            }
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body: stickyCommentText,
+            });
+            core.info(`Updated comment on PR #${prNumber}`);
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: stickyCommentText,
+            });
+            core.info(`Created comment on PR #${prNumber}`);
           }

--- a/.github/actions/set-package-stats/action.yml
+++ b/.github/actions/set-package-stats/action.yml
@@ -16,6 +16,9 @@ inputs:
   size-diff-warning-threshold-kib:
     default: "128"
     description: file size warning threshold in KiB
+  pr-number:
+    required: false
+    description: "The PR number to inform. If not provided, the inform-package-stats step will be skipped."
 
 runs:
   using: "composite"
@@ -118,6 +121,8 @@ runs:
         name: ${{ steps.create-stats-json.outputs.OUTPUT_FILENAME }}
 
     - uses: ./.github/actions/inform-package-stats
+      if: ${{ inputs.pr-number != '' }}
       with:
+        pr-number: ${{ inputs.pr-number }}
         stats-file-prefix: ${{ inputs.stats-file-prefix }}
         size-diff-warning-threshold-kib: ${{ inputs.size-diff-warning-threshold-kib }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -489,6 +489,7 @@ jobs:
         key: browser
         name: "@stlite/browser"
         input-path: packages/browser/package.tgz
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
 
     # Also get stats of the built wheel files of stlite-lib and streamlit in this job.
     - name: Get the built wheel file path
@@ -507,6 +508,7 @@ jobs:
         key: stlite-lib-wheel
         name: "stlite-lib wheel (built as a part of @stlite/browser)"
         input-path: ${{ steps.get-wheel-file-path.outputs.STLITE_LIB_WHEEL_FILEPATH }}
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
     - name: "Inform the package stats of streamlit wheel"
       uses: ./.github/actions/set-package-stats
       continue-on-error: true
@@ -514,6 +516,7 @@ jobs:
         key: streamlit-wheel
         name: "streamlit wheel (built as a part of @stlite/browser)"
         input-path: ${{ steps.get-wheel-file-path.outputs.STREAMLIT_WHEEL_FILEPATH }}
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
 
   build-react:
     if: ${{ ! failure() }}  # This job should run even if the depending jobs are skipped, but not when those jobs failed.
@@ -564,6 +567,7 @@ jobs:
         key: react
         name: "@stlite/react"
         input-path: packages/react/package.tgz
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
 
   build-sharing:
     if: ${{ ! failure() }}  # This job should run even if the depending jobs are skipped, but not when those jobs failed: https://qiita.com/abetomo/items/d9ede7dbeeb24f723fc5#%E8%A8%AD%E5%AE%9A%E4%BE%8B4
@@ -616,6 +620,7 @@ jobs:
         key: sharing
         name: "stlite sharing"
         input-path: packages/sharing/build
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
 
   build-sharing-editor:
     if: ${{ ! failure() }}  # This job should run even if the depending jobs are skipped, but not when those jobs failed: https://qiita.com/abetomo/items/d9ede7dbeeb24f723fc5#%E8%A8%AD%E5%AE%9A%E4%BE%8B4
@@ -663,6 +668,7 @@ jobs:
         key: sharing-editor
         name: "stlite sharing editor"
         input-path: packages/sharing-editor/dist
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
 
   build-desktop:
     if: ${{ ! failure() }}  # This job should run even if the depending jobs are skipped, but not when those jobs failed: https://qiita.com/abetomo/items/d9ede7dbeeb24f723fc5#%E8%A8%AD%E5%AE%9A%E4%BE%8B4
@@ -723,6 +729,7 @@ jobs:
         key: desktop
         name: "@stlite/desktop"
         input-path: packages/desktop/package.tgz
+        pr-number: ${{ needs.set-build-info.outputs.pr-number }}
 
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Make pr-number a required input for inform-package-stats
- Simplify the action to handle a single PR directly instead of inferring from event types and handling arrays
- Get commit SHA from PR's head.sha instead of event context
- Add pr-number input to set-package-stats and pass it through
- Update all usages in test-build.yml to pass pr-number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package statistics reporting for pull requests with simplified PR identification and more reliable comment management on PR threads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->