### PR TITLE
Add section-content-file option to sticky-comment-add-section action

### DIFF
--- a/.github/actions/inform-package-stats/action.yml
+++ b/.github/actions/inform-package-stats/action.yml
@@ -183,22 +183,12 @@ runs:
 
           fs.writeFileSync('comment.txt', comment);
 
-    - name: Read comment content
-      id: read-comment
-      shell: bash
-      run: |
-        cd "$PACKAGE_STATS_WORKING_DIR"
-        {
-          echo 'CONTENT<<EOF'
-          cat comment.txt
-          echo 'EOF'
-        } >> "$GITHUB_OUTPUT"
-
+    # Pass content via file to avoid "argument too long" errors when the package stats content is large.
     - name: Add package stats section to sticky comment
       uses: ./.github/actions/sticky-comment-add-section
       with:
         pr-number: ${{ inputs.pr-number }}
         section-id: package-stats
         section-title: "## Package Stats"
-        section-content: ${{ steps.read-comment.outputs.CONTENT }}
+        section-content-file: ${{ env.PACKAGE_STATS_WORKING_DIR }}/comment.txt
         order: "10"

--- a/.github/actions/sticky-comment-add-section/action.yml
+++ b/.github/actions/sticky-comment-add-section/action.yml
@@ -11,8 +11,11 @@ inputs:
     required: true
     description: "Display title for this section (markdown header, e.g., '## Package Stats')"
   section-content:
-    required: true
-    description: "Markdown content for this section"
+    required: false
+    description: "Markdown content for this section. Mutually exclusive with section-content-file."
+  section-content-file:
+    required: false
+    description: "Path to a file containing the markdown content for this section. Use this for large content to avoid 'argument too long' errors. Mutually exclusive with section-content."
   order:
     required: false
     default: "50"
@@ -28,14 +31,37 @@ runs:
         SECTION_ID: ${{ inputs.section-id }}
         SECTION_TITLE: ${{ inputs.section-title }}
         SECTION_CONTENT: ${{ inputs.section-content }}
+        SECTION_CONTENT_FILE: ${{ inputs.section-content-file }}
         SECTION_ORDER: ${{ inputs.order }}
       with:
         script: |
+          const fs = require("fs");
+
           const prNumber = parseInt(process.env.PR_NUMBER);
           const sectionId = process.env.SECTION_ID;
           const sectionTitle = process.env.SECTION_TITLE;
-          const sectionContent = process.env.SECTION_CONTENT;
+          const sectionContentRaw = process.env.SECTION_CONTENT;
+          const sectionContentFile = process.env.SECTION_CONTENT_FILE;
           const sectionOrder = parseInt(process.env.SECTION_ORDER) || 50;
+
+          // Validate that exactly one of section-content or section-content-file is provided
+          let sectionContent;
+          if (sectionContentRaw && sectionContentFile) {
+            core.setFailed("Only one of section-content or section-content-file should be provided, not both.");
+            return;
+          } else if (sectionContentRaw) {
+            sectionContent = sectionContentRaw;
+          } else if (sectionContentFile) {
+            try {
+              sectionContent = fs.readFileSync(sectionContentFile, "utf8");
+            } catch (error) {
+              core.setFailed(`Failed to read section content from file: ${sectionContentFile}. Error: ${error.message}`);
+              return;
+            }
+          } else {
+            core.setFailed("Either section-content or section-content-file must be provided.");
+            return;
+          }
 
           if (!prNumber || isNaN(prNumber)) {
             core.info("No valid PR number provided, skipping comment update.");


### PR DESCRIPTION
The sticky-comment-add-section action now accepts both section-content (raw string) and section-content-file (file path) inputs. This allows passing large content via file to avoid "argument too long" errors.

Updated inform-package-stats to use section-content-file for the potentially large package stats content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved content handling in GitHub Actions workflows to support file-based input alongside direct content input, enhancing flexibility and robustness.
  * Optimized how large content is transmitted between workflow steps to avoid potential transmission limitations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->