### PR TITLE
Fix template expression in inform-package-stats action.yml description

### DIFF
--- a/.github/actions/inform-package-stats/action.yml
+++ b/.github/actions/inform-package-stats/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "The PR number to inform."
   sticky-id:
     required: false
-    description: "Unique identifier for this sticky comment, passed to sticky-comment-add-section (defaults to github.sha downstream via `${{ inputs.sticky-id || github.sha }}`)."
+    description: "Unique identifier for this sticky comment, passed to sticky-comment-add-section (defaults to github.sha downstream)."
   stats-file-prefix:
     default: "package-stats."
     description: stats file name prefix


### PR DESCRIPTION
Remove the template expression from the sticky-id input description. GitHub Actions evaluates template expressions even in description strings, causing validation errors since the inputs context isn't available in action metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions configuration documentation for improved clarity on parameter defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->