### PR TITLE
Replace pandas with faker in requirements demo for E2E testability

### DIFF
--- a/packages/browser/demos/requirements/index.html
+++ b/packages/browser/demos/requirements/index.html
@@ -12,25 +12,26 @@
       import { mount } from "{{STLITE_JS_URL}}";
       mount(
         {
-          requirements: ["pandas"],
+          requirements: ["faker"],
           entrypoint: "streamlit_app.py",
           files: {
             "streamlit_app.py": `
 import streamlit as st
-import pandas as pd
+from faker import Faker
+
+# Set seed for deterministic output (useful for testing)
+Faker.seed(12345)
+fake = Faker()
 
 st.title("Requirements Demo")
 st.write("This demo shows how to install Python packages.")
 
-# Create a simple DataFrame
-df = pd.DataFrame({
-    'Name': ['Alice', 'Bob', 'Charlie'],
-    'Age': [25, 30, 35],
-    'City': ['New York', 'London', 'Paris']
-})
+st.subheader("Faker Examples")
 
-st.write("Here's a DataFrame created with pandas:")
-st.dataframe(df)
+st.write("Name: " + fake.name())
+st.write("Email: " + fake.email())
+st.write("Address: " + fake.address().replace("\\n", ", "))
+st.write("Company: " + fake.company())
 `,
           },
         },

--- a/packages/browser/e2e-tests/tests/requirements.test.ts
+++ b/packages/browser/e2e-tests/tests/requirements.test.ts
@@ -22,15 +22,15 @@ test.describe("Requirements Installation Test", () => {
       page.locator('text="This demo shows how to install Python packages."'),
     ).toBeVisible();
 
-    // Check if the DataFrame is rendered (pandas was installed and used)
-    await expect(
-      page.locator('text="Here\'s a DataFrame created with pandas:"'),
-    ).toBeVisible();
+    // Check if Faker examples subheader is visible
+    await expect(page.locator('text="Faker Examples"')).toBeVisible();
 
-    // Check if the DataFrame contains expected data
-    await expect(page.locator('text="Alice"')).toBeVisible();
-    await expect(page.locator('text="Bob"')).toBeVisible();
-    await expect(page.locator('text="Charlie"')).toBeVisible();
+    // Check if Faker output is rendered (faker was installed and used)
+    // With seed 12345, the output is deterministic
+    await expect(page.locator("text=/^Name:/")).toBeVisible();
+    await expect(page.locator("text=/^Email:/")).toBeVisible();
+    await expect(page.locator("text=/^Address:/")).toBeVisible();
+    await expect(page.locator("text=/^Company:/")).toBeVisible();
 
     // Check for dead links
     await expectNoDeadLinks();


### PR DESCRIPTION
The previous demo used pandas with st.dataframe() which renders using Canvas. Canvas-based UI elements are not reliably testable with Playwright, causing flaky or failing E2E tests.
`st.DataFrame` uses [`grid-data-grid`](https://grid.glideapps.com/) that uses Canvas. Canvas is not testable with Playwright as https://stackoverflow.com/questions/79746733/unable-to-click-checkbox-inside-glide-datagrid-cell-using-selenium-or-playwright

This change:
- Replaces pandas with faker library (popular, stable)
- Uses st.write() for text-based output that Playwright can query
- Sets Faker.seed(12345) for deterministic output across test runs
- Updates E2E test to verify Faker output labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated browser demo to generate sample data using Faker, displaying name, email, address, and company fields.
  * Updated end-to-end test assertions to validate the new sample data output format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->