### PR TITLE
Fix the dependency review workflow setup to avoid warning

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -35,4 +35,4 @@ jobs:
         comment-summary-in-pr: always
       #   fail-on-severity: moderate
       #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
-      #   retry-on-snapshot-warnings: true
+        retry-on-snapshot-warnings: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        submodules: true
         persist-credentials: false
     - name: 'Dependency Review'
       uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dependency scan now includes repository submodules during checks.
  * Dependency review action will retry on snapshot-related warnings to reduce false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->