### PR TITLE
Skip changeset check on changesets release PR

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -124,9 +124,14 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Skip if `skip-changeset` label is set
+      - name: Decide whether to skip
         id: skip
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+        # Bypass when:
+        #   - the PR carries the `skip-changeset` label (manual escape hatch), or
+        #   - the PR is the release PR opened by `changesets/action`, which
+        #     consumes (deletes) fragments rather than adding them. Its branch
+        #     name is `changeset-release/<base>` by default.
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') || github.event.pull_request.head.ref == 'changeset-release/main' }}
         run: echo "skipped=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -131,7 +131,7 @@ jobs:
         #   - the PR is the release PR opened by `changesets/action`, which
         #     consumes (deletes) fragments rather than adding them. Its branch
         #     name is `changeset-release/<base>` by default.
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') || github.event.pull_request.head.ref == 'changeset-release/main' }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') || startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}
         run: echo "skipped=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to skip changeset verification for release PRs created by the automated release process (branch name pattern) in addition to the existing label-based skip.
  * The skip decision is now centralized so downstream checks are bypassed when skipping is triggered, reducing unnecessary verification runs for automated releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->