### PR TITLE
Dev/remove web vitals from unused packages

### DIFF
--- a/.changeset/large-trees-lose.md
+++ b/.changeset/large-trees-lose.md
@@ -1,0 +1,6 @@
+---
+"@stlite/browser": patch
+"@stlite/react": patch
+---
+
+Remove web-vitals from @stlite/browser and @stlite/react that don't use it

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -60,8 +60,7 @@
     "typescript-eslint": "^8.46.2",
     "vite": "^7.1.5",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "^4.1.0",
-    "web-vitals": "^4.2.4"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "start": "vite",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,8 +83,7 @@
     "vite-plugin-static-copy": "^3.1.4",
     "vite-plugin-wasm": "^3.5.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^4.1.0",
-    "web-vitals": "^4.2.4"
+    "vitest": "^4.1.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7389,7 +7389,6 @@ __metadata:
     vite: "npm:^7.1.5"
     vite-plugin-dts: "npm:^4.5.4"
     vitest: "npm:^4.1.0"
-    web-vitals: "npm:^4.2.4"
   languageName: unknown
   linkType: soft
 
@@ -7527,7 +7526,6 @@ __metadata:
     vite-plugin-wasm: "npm:^3.5.0"
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:^4.1.0"
-    web-vitals: "npm:^4.2.4"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the unused web-vitals development dependency from @stlite/browser and @stlite/react, reducing development dependency surface. No public APIs or runtime behavior were changed. This is a low-risk maintenance update meant to tidy dev tooling and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->