### PR TITLE
Fix changeset-check job

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,74 @@
+name: Changeset check
+
+# Ensure PRs include a changeset fragment so releases get a changelog entry.
+# See https://github.com/changesets/changesets/blob/main/docs/common-questions.md#how-do-changesets-work-with-ci
+#
+# Split out from `test-build.yml` so label changes only re-run this cheap job
+# — the `labeled` / `unlabeled` event types below make the `skip-changeset`
+# escape hatch effective even when the label is added after the first run.
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions: {}
+
+env:
+  python-version-file: ".python-version"
+  node-version-file: ".nvmrc"
+
+jobs:
+  changeset-check:
+    runs-on: ubuntu-latest
+    steps:
+      # Bypass conditions:
+      #   - the PR carries the `skip-changeset` label (manual escape hatch), or
+      #   - the PR is the release PR opened by `changesets/action`, which
+      #     consumes (deletes) fragments rather than adding them. Its branch
+      #     name is `changeset-release/<base>` by default.
+      - name: Decide whether to run the check
+        id: decide
+        env:
+          HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HAS_SKIP_LABEL" == "true" || "$HEAD_REF" == changeset-release/* ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        with:
+          # Submodules are needed because `yarn install` resolves workspaces
+          # that live inside the `streamlit/` submodule.
+          submodules: true
+          # `fetch-depth: 0` is required so `changeset status --since` can diff against the base branch.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/init-all
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        with:
+          # `python-version-file` is set so `uv` gets installed — the
+          # `packages/tooling` workspace shells out to `uv` during yarn install.
+          python-version-file: ${{ env.python-version-file }}
+          node-version-file: ${{ env.node-version-file }}
+          protoc: false
+
+      - name: Check for changeset
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        # `changeset status --since` exits 0 even when no changeset is present,
+        # so use `--output` to capture the plan as JSON and fail when the set
+        # of new changesets is empty.
+        run: |
+          yarn changeset status --since="origin/${BASE_REF}" --output=changeset-status.json
+          count=$(jq '.changesets | length' changeset-status.json)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No changeset fragment found. Run \`yarn changeset\` to add one, or apply the \`skip-changeset\` label to bypass."
+            exit 1
+          fi

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -124,18 +124,19 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Decide whether to skip
-        id: skip
-        # Bypass when:
-        #   - the PR carries the `skip-changeset` label (manual escape hatch), or
-        #   - the PR is the release PR opened by `changesets/action`, which
-        #     consumes (deletes) fragments rather than adding them. Its branch
-        #     name is `changeset-release/<base>` by default.
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') || startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}
-        run: echo "skipped=true" >> "$GITHUB_OUTPUT"
+      # Bypass conditions:
+      #   - the PR carries the `skip-changeset` label (manual escape hatch), or
+      #   - the PR is the release PR opened by `changesets/action`, which
+      #     consumes (deletes) fragments rather than adding them. Its branch
+      #     name is `changeset-release/<base>` by default.
+      - name: Decide whether to run the check
+        id: decide
+        env:
+          SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') || startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}
+        run: echo "run=$([[ \"$SKIP\" == \"true\" ]] && echo false || echo true)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ steps.skip.outputs.skipped != 'true' }}
+        if: ${{ steps.decide.outputs.run == 'true' }}
         with:
           # Submodules are needed because `yarn install` resolves workspaces
           # that live inside the `streamlit/` submodule.
@@ -145,13 +146,13 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/init-all
-        if: ${{ steps.skip.outputs.skipped != 'true' }}
+        if: ${{ steps.decide.outputs.run == 'true' }}
         with:
           node-version-file: ${{ env.node-version-file }}
           protoc: false
 
       - name: Check for changeset
-        if: ${{ steps.skip.outputs.skipped != 'true' }}
+        if: ${{ steps.decide.outputs.run == 'true' }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: yarn changeset status --since="origin/${BASE_REF}"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -155,7 +155,16 @@ jobs:
         if: ${{ steps.decide.outputs.run == 'true' }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: yarn changeset status --since="origin/${BASE_REF}"
+        # `changeset status --since` exits 0 even when no changeset is present,
+        # so use `--output` to capture the plan as JSON and fail when the set
+        # of new changesets is empty.
+        run: |
+          yarn changeset status --since="origin/${BASE_REF}" --output=changeset-status.json
+          count=$(jq '.changesets | length' changeset-status.json)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No changeset fragment found. Run \`yarn changeset\` to add one, or apply the \`skip-changeset\` label to bypass."
+            exit 1
+          fi
 
   changes:  # See https://github.com/dorny/paths-filter#examples
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -147,9 +147,6 @@ jobs:
       - uses: ./.github/actions/init-all
         if: ${{ steps.skip.outputs.skipped != 'true' }}
         with:
-          # `python-version-file` is set so `uv` gets installed — the
-          # `packages/tooling` workspace shells out to `uv` during yarn install.
-          python-version-file: ${{ env.python-version-file }}
           node-version-file: ${{ env.node-version-file }}
           protoc: false
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -137,6 +137,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ steps.skip.outputs.skipped != 'true' }}
         with:
+          # Submodules are needed because `yarn install` resolves workspaces
+          # that live inside the `streamlit/` submodule.
+          submodules: true
           # `fetch-depth: 0` is required so `changeset status --since` can diff against the base branch.
           fetch-depth: 0
           persist-credentials: false
@@ -144,6 +147,9 @@ jobs:
       - uses: ./.github/actions/init-all
         if: ${{ steps.skip.outputs.skipped != 'true' }}
         with:
+          # `python-version-file` is set so `uv` gets installed — the
+          # `packages/tooling` workspace shells out to `uv` during yarn install.
+          python-version-file: ${{ env.python-version-file }}
           node-version-file: ${{ env.node-version-file }}
           protoc: false
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -113,59 +113,6 @@ jobs:
           name: changesets-published-packages
           path: changesets-published-packages
 
-  changeset-check:
-    # Ensure PRs include a changeset fragment so releases get a changelog entry.
-    # Bypass by adding the `skip-changeset` label to the PR.
-    # See https://github.com/changesets/changesets/blob/main/docs/common-questions.md#how-do-changesets-work-with-ci
-    #
-    # Note: the `if:` only gates on the event kind — we always *run* the job on
-    # PRs (even when the escape-hatch label is set) so a required status check
-    # in branch protection resolves to success instead of staying pending.
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      # Bypass conditions:
-      #   - the PR carries the `skip-changeset` label (manual escape hatch), or
-      #   - the PR is the release PR opened by `changesets/action`, which
-      #     consumes (deletes) fragments rather than adding them. Its branch
-      #     name is `changeset-release/<base>` by default.
-      - name: Decide whether to run the check
-        id: decide
-        env:
-          SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') || startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}
-        run: echo "run=$([[ \"$SKIP\" == \"true\" ]] && echo false || echo true)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ steps.decide.outputs.run == 'true' }}
-        with:
-          # Submodules are needed because `yarn install` resolves workspaces
-          # that live inside the `streamlit/` submodule.
-          submodules: true
-          # `fetch-depth: 0` is required so `changeset status --since` can diff against the base branch.
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: ./.github/actions/init-all
-        if: ${{ steps.decide.outputs.run == 'true' }}
-        with:
-          node-version-file: ${{ env.node-version-file }}
-          protoc: false
-
-      - name: Check for changeset
-        if: ${{ steps.decide.outputs.run == 'true' }}
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        # `changeset status --since` exits 0 even when no changeset is present,
-        # so use `--output` to capture the plan as JSON and fail when the set
-        # of new changesets is empty.
-        run: |
-          yarn changeset status --since="origin/${BASE_REF}" --output=changeset-status.json
-          count=$(jq '.changesets | length' changeset-status.json)
-          if [ "$count" -eq 0 ]; then
-            echo "::error::No changeset fragment found. Run \`yarn changeset\` to add one, or apply the \`skip-changeset\` label to bypass."
-            exit 1
-          fi
-
   changes:  # See https://github.com/dorny/paths-filter#examples
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Checks out submodules and runs init-all so the changeset CLI is resolved through the normal package.json / yarn.lock flow that Dependabot tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated changeset validation workflow to ensure PRs include changeset fragments (fails PRs that lack them unless explicitly bypassed).
  * Removed an older, duplicate changeset check to simplify CI.
  * Improved CI gating and enabled repository submodule checkout to make dependency setup and PR checks more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->