### PR TITLE
Add uv dependency cooldown to mitigate supply-chain risk

### DIFF
--- a/.changeset/uv-dependency-cooldown.md
+++ b/.changeset/uv-dependency-cooldown.md
@@ -1,0 +1,8 @@
+---
+"@stlite/kernel": patch
+"@stlite/browser": patch
+"@stlite/desktop": patch
+"@stlite/react": patch
+---
+
+Configure a 1-week `exclude-newer` cooldown for uv resolution to reduce exposure to PyPI supply-chain attacks when resolving the Python dependencies used to build the kernel's Pyodide wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,13 @@ dev = [
 
 [tool.uv.workspace]
 members = ["packages/kernel/py/stlite-lib"]
+
+[tool.uv]
+# Require a uv version that supports relative `exclude-newer` durations
+# (introduced in uv 0.9.17).
+required-version = ">=0.9.17"
+# Dependency cooldown: ignore package releases published within the last week
+# to reduce exposure to PyPI supply-chain attacks (compromised versions are
+# typically yanked well within this window).
+# https://docs.astral.sh/uv/concepts/resolution/#exclude-newer
+exclude-newer = "1 week"


### PR DESCRIPTION
Configure `exclude-newer = "1 week"` in the workspace root so PyPI releases less than a week old are ignored during resolution. Also pin `required-version = ">=0.9.17"` since relative durations require that version of uv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package versions with patch releases.
  * Enhanced dependency resolution security by implementing a 1-week cooldown period to reduce supply-chain attack exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->