### PR TITLE
Use GitHub App token in dependabot-changeset workflow

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -20,12 +20,23 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: read
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+
+      # Use a GitHub App token so the commit triggers downstream workflows.
+      # Commits pushed with the default GITHUB_TOKEN don't trigger other
+      # workflows (e.g. test-build.yml), which would leave the PR stuck on
+      # `changeset-check`.
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.CHANGESETS_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Create changeset via Contents API
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -35,6 +46,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { DEPS, UPDATE_TYPE, PR_NUMBER, HEAD_REF } = process.env;
             const path = `.changeset/dependabot-pr-${PR_NUMBER}.md`;


### PR DESCRIPTION
Commits pushed with the default GITHUB_TOKEN don't trigger downstream workflows, so the changeset commit wasn't kicking off test-build.yml and Dependabot PRs stalled on the changeset-check gate. Reuse the whitphx-changesets-bot App token (already used by the changesets job) so the commit fires CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automation workflow configuration to use enhanced authentication for processing changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->