### PR TITLE
Update web-vitals to 5.2.0

### DIFF
--- a/.changeset/update-web-vitals-5-2-0.md
+++ b/.changeset/update-web-vitals-5-2-0.md
@@ -1,0 +1,6 @@
+---
+"@stlite/sharing": patch
+"@stlite/sharing-editor": patch
+---
+
+Update web-vitals to 5.2.0 and replace the removed `onFID` metric with `onINP`.

--- a/packages/sharing-editor/package.json
+++ b/packages/sharing-editor/package.json
@@ -21,7 +21,7 @@
     "react-router-dom": "^7.10.1",
     "superstruct": "^2.0.2",
     "usehooks-ts": "^3.1.0",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^5.2.0"
   },
   "scripts": {
     "start:web": "cross-env SHARING_APP_URL=http://localhost:3000/ vite",

--- a/packages/sharing-editor/src/reportWebVitals.ts
+++ b/packages/sharing-editor/src/reportWebVitals.ts
@@ -2,9 +2,9 @@ import type { Metric } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: (metric: Metric) => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+    import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
       onCLS(onPerfEntry);
-      onFID(onPerfEntry);
+      onINP(onPerfEntry);
       onFCP(onPerfEntry);
       onLCP(onPerfEntry);
       onTTFB(onPerfEntry);

--- a/packages/sharing/package.json
+++ b/packages/sharing/package.json
@@ -10,7 +10,7 @@
     "@types/react-dom": "^18.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/packages/sharing/src/reportWebVitals.ts
+++ b/packages/sharing/src/reportWebVitals.ts
@@ -2,9 +2,9 @@ import type { Metric } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: (metric: Metric) => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+    import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
       onCLS(onPerfEntry);
-      onFID(onPerfEntry);
+      onINP(onPerfEntry);
       onFCP(onPerfEntry);
       onLCP(onPerfEntry);
       onTTFB(onPerfEntry);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7595,7 +7595,7 @@ __metadata:
     usehooks-ts: "npm:^3.1.0"
     vite: "npm:^7.1.5"
     vitest: "npm:^4.1.0"
-    web-vitals: "npm:^4.2.4"
+    web-vitals: "npm:^5.2.0"
   languageName: unknown
   linkType: soft
 
@@ -7622,7 +7622,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.46.2"
     vite: "npm:^7.1.5"
-    web-vitals: "npm:^4.2.4"
+    web-vitals: "npm:^5.2.0"
   languageName: unknown
   linkType: soft
 
@@ -30441,10 +30441,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-vitals@npm:^4.2.4":
-  version: 4.2.4
-  resolution: "web-vitals@npm:4.2.4"
-  checksum: 10c0/383c9281d5b556bcd190fde3c823aeb005bb8cf82e62c75b47beb411014a4ed13fa5c5e0489ed0f1b8d501cd66b0bebcb8624c1a75750bd5df13e2a3b1b2d194
+"web-vitals@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "web-vitals@npm:5.2.0"
+  checksum: 10c0/b8d4d02025afb5e1668fb9725c337616c266d9891979b1e58f81b610ee3bf53727b97babb16322fdac2b9d43ce6daa1787f42b959695796474a2061e79e219d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated web-vitals dependency from 4.2.4 to 5.2.0 across sharing packages.
* **Other**
  * Performance telemetry now reports the INP metric instead of FID; other metrics remain unchanged.
* **Changelog**
  * Added a changeset entry documenting the dependency and metric update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->