### PR TITLE
fix(kernel): empty DataFrame crashes the page render (#2011)

### DIFF
--- a/.changeset/fix-empty-dataframe-render.md
+++ b/.changeset/fix-empty-dataframe-render.md
@@ -1,0 +1,5 @@
+---
+"@stlite/kernel": patch
+---
+
+Fix `st.dataframe([])` and other empty DataFrames crashing the page render with a Parquet error ("Repetition level must be defined for a primitive type"). Empty DataFrames now render as empty tables, matching Streamlit's behavior.


### PR DESCRIPTION
Fixes #2011

`st.dataframe([])` (and any DataFrame with no columns) crashed the page render with "Parquet error: Repetition level must be defined for a primitive type" — fastparquet emits a valid Parquet file for a 0-column DataFrame but parquet-wasm cannot parse it. The Streamlit submodule now returns empty bytes in that case and the frontend treats empty bytes as an empty table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where empty DataFrames (e.g., `st.dataframe([])`) caused page rendering to crash. Empty DataFrames now render as empty tables, consistent with Streamlit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->