### PR TITLE
fix(inform-package-stats): correct inverted isDiff sense

### DIFF
--- a/.github/actions/inform-package-stats/action.yml
+++ b/.github/actions/inform-package-stats/action.yml
@@ -136,7 +136,10 @@ runs:
                 fs.unlinkSync('temp1.txt');
                 fs.unlinkSync('temp2.txt');
 
-                resolve({ isDiff: code === 0, diff: output });
+                // GNU diff exits 0 when files are identical, 1 when they
+                // differ; the previous `code === 0` made `isDiff` true on
+                // identical input, the opposite of what the name implies.
+                resolve({ isDiff: code !== 0, diff: output });
               });
             });
           }


### PR DESCRIPTION
## Summary

GNU `diff` exits **0 when files are identical** and **1 when they differ**, so `isDiff: code === 0` set the field to `true` on identical input — the opposite of what the name implies.

## Test plan

- [x] No behavioral change expected (the field is currently unused downstream — only `fileSizesCmp.diff` is consumed). Code-quality fix.
- [ ] CI green.

## Notes

Spotted while building a similar bundle-size report on whitphx/anipres ([anipres#480](https://github.com/whitphx/anipres/pull/480)) which is patterned after this action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed diff detection logic in the package stats GitHub Action to correctly identify when package files have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->