### PR TITLE
fix(inform-package-stats): show diff annotation when base size is 0

### DIFF
--- a/.github/actions/inform-package-stats/action.yml
+++ b/.github/actions/inform-package-stats/action.yml
@@ -157,7 +157,11 @@ runs:
             const sizeDiffKiB = sizeKiB - baseSizeKiB;
             const shouldWarn = Math.abs(sizeDiffKiB) >= ${{ inputs.size-diff-warning-threshold-kib }};
             const sizeDiffFormatter = new Intl.NumberFormat("en-US", { signDisplay: "always" });
-            const sizeDiffStr = baseSizeKiB ? `(${baseSizeKiB} kiB ${shouldWarn ? '⚠️ ' : ''}**${sizeDiffFormatter.format(sizeDiffKiB)} kiB**)` : "";
+            // `baseSizeKiB ? ...` is falsy for 0, so a bundle that grew
+            // from 0 → N kiB renders with no diff annotation — masking
+            // the very growth users care about. Switch to a null-check
+            // so only the "no baseline at all" case suppresses it.
+            const sizeDiffStr = baseSizeKiB != null ? `(${baseSizeKiB} kiB ${shouldWarn ? '⚠️ ' : ''}**${sizeDiffFormatter.format(sizeDiffKiB)} kiB**)` : "";
 
             const fileSizesCmp = await compareStrings(baseContent?.filelist?.sizes ?? "", content.filelist.sizes)
 


### PR DESCRIPTION
## Summary

`baseSizeKiB ? ...` treats `0` as falsy, so a bundle that grew from `0 → N kiB` renders with **no diff annotation** — masking the very growth users care about. Switch to `baseSizeKiB != null ? ...` so only the "no baseline at all" case (`undefined`) suppresses the annotation.

## Test plan

- [x] Behavioral fix; rare edge case (a real package being 0 KiB in base is unusual but possible — e.g., a placeholder package that just got real files added).
- [ ] CI green.

## Notes

Spotted while building a similar bundle-size report on whitphx/anipres ([anipres#480](https://github.com/whitphx/anipres/pull/480)) which is patterned after this action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package size diff reporting in pull request comments to accurately display size changes for newly added and modified packages, ensuring developers have complete visibility into bundle size impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->