### PR TITLE
fix(build): pin pyodide xbuildenv to runtime version and bump pyodide-lock

### DIFF
--- a/.changeset/fix-pyodide-xbuildenv-install.md
+++ b/.changeset/fix-pyodide-xbuildenv-install.md
@@ -1,0 +1,8 @@
+---
+"@stlite/kernel": patch
+"@stlite/browser": patch
+"@stlite/react": patch
+"@stlite/desktop": patch
+---
+
+Fix `make venv` failing during `pyodide xbuildenv install` after upstream Pyodide 0.29.4 shipped a `pyodide-lock.json` under a newer schema. Bump `pyodide-lock` 0.1.2 → 0.1.3 (which makes the dropped `info.version` field optional) and pin the xbuildenv install to the runtime Pyodide version so future upstream patch releases can no longer break the frozen build env.

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ $(if $(shell command -v yarn),,@echo "WARNING: yarn is not installed. Please ins
 STREAMLIT_WHEEL_FILE_NAME := $(shell yarn workspace @stlite/tooling get-streamlit-wheel-file-name py)
 STREAMLIT_COMPILED_WHEEL_FILE_NAME := $(shell yarn workspace @stlite/tooling get-streamlit-wheel-file-name cp)
 
+# Pin xbuildenv to the Pyodide runtime version. Without an explicit version,
+# `pyodide xbuildenv install` floats to the latest patch pyodide-build's
+# compat range allows, and a fresh upstream Pyodide release can ship a
+# pyodide-lock schema that the frozen uv.lock can no longer parse.
+# Bump alongside the runtime Pyodide version: packages/kernel/package.json,
+# packages/desktop/package.json, packages/kernel/src/worker.ts (CDN URL),
+# packages/kernel/py/stlite-lib/pyproject.toml (pyodide-py).
+PYODIDE_VERSION := 0.29.3
+
 node_modules := $(BUILD_STATE_DIR)/node_modules/.built
 venv := $(BUILD_STATE_DIR)/venv/.built
 common := $(BUILD_STATE_DIR)/common/.built
@@ -87,7 +96,7 @@ $(venv): .python-version pyproject.toml uv.lock packages/kernel/py/stlite-lib/py
 	uv sync $(UV_SYNC_FLAGS) --all-packages --all-groups
 	uv pip install --group streamlit/pyproject.toml:dev
 	-uv run pyodide xbuildenv uninstall
-	uv run pyodide xbuildenv install
+	uv run pyodide xbuildenv install $(PYODIDE_VERSION)
 	@mkdir -p $(dir $@)
 	@touch $@
 	@echo "\nPython virtualenv has been set up. Run the command below to activate.\n\n. $(VENV_PATH)/bin/activate"

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-09T13:36:37.568158Z"
+exclude-newer = "2026-05-01T13:41:21.115379Z"
 exclude-newer-span = "P1W"
 
 [manifest]
@@ -1075,14 +1075,14 @@ wheels = [
 
 [[package]]
 name = "pyodide-lock"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://pypi.flatt.tech/files/packages/51/7d/f6cda69ebf4af81a4389d522be998a503dfe1880173a843abd3e97f3d2d2/pyodide_lock-0.1.2.tar.gz", hash = "sha256:5c438045833b40f937b3017e8ca6dceae4ec1122eb845ccac00f5ae234db9a4c", size = 54230, upload-time = "2026-02-27T05:21:39.308Z" }
+sdist = { url = "https://pypi.flatt.tech/files/packages/7a/4c/80bf2cfa237c405d41730d4f86c53d2d4d49aea2aaa8c74894156bcf4f60/pyodide_lock-0.1.3.tar.gz", hash = "sha256:5ed700b4b1b88313d9c56bab721d5a4ed57304bbe83c172b647f74e1140e2177", size = 54432, upload-time = "2026-04-24T09:02:54.208Z" }
 wheels = [
-    { url = "https://pypi.flatt.tech/files/packages/bc/2a/2e695f75e699824156dc84f3f267344fb4225ec305a5fa111f8a0c3574df/pyodide_lock-0.1.2-py3-none-any.whl", hash = "sha256:439c4a56b5361d3c7c368f5613eccdc0839e0f5d78899962176e4ab533eed2a3", size = 15457, upload-time = "2026-02-27T05:21:38.079Z" },
+    { url = "https://pypi.flatt.tech/files/packages/c4/28/5afbe23595edf79560ca5237ba9f008594cdf36b9cbf90e06df06ca04ce7/pyodide_lock-0.1.3-py3-none-any.whl", hash = "sha256:71d3e8ef72cc020e45eabd35cb36480437d2639bc756392f02ca3bd709504103", size = 15442, upload-time = "2026-04-24T09:02:52.764Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pyodide 0.29.4 (released 2026-05-07) shipped `pyodide-lock.json` under the new pyodide-lock 0.1.3 schema, which dropped the `info.version` field. The frozen `pyodide-lock 0.1.2` in `uv.lock` still required that field, so `pyodide xbuildenv install` blew up with a pydantic `ValidationError` in CI ([example failing run](https://github.com/whitphx/stlite/actions/runs/25547801143/job/74988187997?pr=2023)).
- Bump `pyodide-lock` 0.1.2 → 0.1.3 in `uv.lock` (allowed by `pyodide-build==0.30.7`'s `pyodide-lock~=0.1.0` spec).
- Pin `pyodide xbuildenv install` to the runtime Pyodide version (`$(PYODIDE_VERSION)` = `0.29.3`) so future upstream patch releases can't float in and break the frozen build env again. `exclude-newer` only gates uv's PyPI resolution; xbuildenv downloads come straight from GitHub releases and bypass that cooldown.

## Test plan

- [x] `pyodide-build 0.30.7` + `pyodide-lock 0.1.3` + Python 3.13 → `pyodide xbuildenv install 0.29.3` succeeds locally
- [x] Same combination → `pyodide xbuildenv install 0.29.4` (the previously-failing version) also succeeds
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures during environment setup that occurred with newer Pyodide versions. The build system now uses a pinned Pyodide version to ensure consistent and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->