### PR TITLE
ASGI bridge spike: drive Streamlit's Starlette app from JS

### DIFF
--- a/packages/kernel/py/stlite-lib/stlite_lib/asgi_app.py
+++ b/packages/kernel/py/stlite-lib/stlite_lib/asgi_app.py
@@ -1,0 +1,184 @@
+"""ASGI bridge between the JS worker and Streamlit's Starlette app.
+
+This is the stlite-side counterpart to packages/kernel/src/asgi-bridge.ts.
+Instead of emulating Streamlit's HTTP/WebSocket server (the legacy approach in
+stlite_lib.server.Server), we instantiate Streamlit's upstream Starlette ASGI
+application and let JS drive it through the ASGI protocol:
+https://asgi.readthedocs.io/en/latest/specs/main.html
+
+The JS side wraps each request as an ASGI ``scope`` and supplies async
+``receive`` / ``send`` callables (proxied via pyodide.ffi). All HTTP routes,
+WebSocket negotiation, session middleware, etc. live in upstream Streamlit.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+    from streamlit.web.server.starlette.starlette_app import App
+
+    AsgiMessage = MutableMapping[str, Any]
+
+
+def create_app(script_path: str) -> App:
+    """Build a Streamlit ASGI app for ``script_path``.
+
+    The returned object is callable as ``await app(scope, receive, send)``.
+    """
+    # Imported lazily so a stlite worker that never reaches the ASGI path
+    # (e.g. an early boot failure) doesn't pay the import cost.
+    from streamlit.web.server.starlette.starlette_app import App
+
+    return App(script_path)
+
+
+async def run_lifespan_startup(app: App) -> dict[str, Any]:
+    """Drive the ASGI lifespan startup handshake against ``app``.
+
+    Returns the state dict yielded by the lifespan context manager (Starlette
+    converts ``lifespan.startup.complete`` / ``.shutdown.complete`` events into
+    ``app.state``). The caller is responsible for invoking
+    :func:`run_lifespan_shutdown` when the app is torn down.
+
+    Note that :func:`call_asgi` rebinds ``runtime_contextvar`` for every
+    http/websocket call; we don't bother setting it here because the lifespan
+    task only ever talks to ``app._runtime`` directly.
+    """
+    import asyncio
+
+    received_startup = asyncio.Event()
+    startup_done = asyncio.Event()
+    shutdown_requested = asyncio.Event()
+
+    async def receive() -> AsgiMessage:
+        if not received_startup.is_set():
+            received_startup.set()
+            return {"type": "lifespan.startup"}
+        await shutdown_requested.wait()
+        return {"type": "lifespan.shutdown"}
+
+    state: dict[str, Any] = {}
+
+    async def send(event: AsgiMessage) -> None:
+        msg_type = event.get("type")
+        if msg_type == "lifespan.startup.complete":
+            startup_done.set()
+        elif msg_type == "lifespan.startup.failed":
+            startup_done.set()
+            raise RuntimeError(
+                f"Streamlit ASGI lifespan startup failed: {event.get('message')}"
+            )
+        elif msg_type == "lifespan.shutdown.complete":
+            pass
+
+    # Run the lifespan coroutine on its own task so the JS side can later
+    # signal shutdown via the returned ``shutdown_requested`` event.
+    scope = {"type": "lifespan", "asgi": {"version": "3.0", "spec_version": "2.0"}}
+    lifespan_task = asyncio.create_task(app(scope, receive, send))
+
+    # Wait for either startup.complete or the lifespan task to crash early.
+    done, _pending = await asyncio.wait(
+        {asyncio.create_task(startup_done.wait()), lifespan_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    if lifespan_task in done and not startup_done.is_set():
+        # Surface the exception from the lifespan task.
+        await lifespan_task
+
+    state["_shutdown_event"] = shutdown_requested
+    state["_lifespan_task"] = lifespan_task
+    return state
+
+
+async def run_lifespan_shutdown(lifespan_state: dict[str, Any]) -> None:
+    """Signal ``lifespan.shutdown`` and wait for the lifespan task to finish."""
+    shutdown_event = lifespan_state.get("_shutdown_event")
+    lifespan_task = lifespan_state.get("_lifespan_task")
+    if shutdown_event is None or lifespan_task is None:
+        return
+    shutdown_event.set()
+    await lifespan_task
+
+
+def _bytesify(value: Any) -> Any:
+    """Recursively convert ``memoryview`` to ``bytes`` in nested structures.
+
+    Pyodide maps JS ``Uint8Array`` to Python ``memoryview`` by default, but
+    Starlette (and the ASGI spec) require header names/values and body chunks
+    to be ``bytes`` — ``memoryview.decode(...)`` doesn't exist.
+    """
+    if isinstance(value, memoryview):
+        return value.tobytes()
+    if isinstance(value, dict):
+        return {k: _bytesify(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_bytesify(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_bytesify(v) for v in value)
+    return value
+
+
+def _to_py(value: Any) -> Any:
+    """Convert a Pyodide JsProxy to a Python object, if needed.
+
+    Plain JS objects come into Python as JsProxy. ASGI handlers read them
+    with subscript (``scope["type"]``), which a JsProxy doesn't support
+    unless it wraps a Map/Array. ``.to_py()`` recursively converts the
+    object tree. The check is duck-typed so Python objects (already dicts,
+    lists, bytes) pass through unchanged. We additionally normalize
+    ``memoryview`` → ``bytes`` so ASGI-spec consumers get what they expect.
+    """
+    to_py = getattr(value, "to_py", None)
+    if callable(to_py):
+        return _bytesify(to_py())
+    return value
+
+
+async def call_asgi(
+    app: App,
+    scope: Any,
+    receive: Any,
+    send: Any,
+) -> None:
+    """Call an ASGI app with scope/receive/send originating from JS.
+
+    Converts JS plain objects to Python dicts at the boundary so the app
+    can use the standard ASGI accessors. ``send`` is passed through —
+    the JS-side ``send`` handler already accepts JsProxy events.
+
+    Each call also binds ``streamlit.runtime.runtime_contextvar`` to the
+    App's runtime instance. The Streamlit script runner and several
+    runtime helpers fetch it via ``Runtime.get_instance()``; without
+    this binding the script execution task spawned during request
+    handling raises ``Exception: Runtime instance not created yet``.
+    Setting it here (not in run_lifespan_startup) is intentional: each
+    JS→Python ASGI call lands in a fresh Pyodide asyncio task whose
+    context doesn't inherit the value bound in the lifespan task, so
+    we need to re-bind on every entry. The PEP 567 contextvar set then
+    propagates to any task the request handler spawns (e.g. the script
+    runner coroutine).
+    """
+    from streamlit.runtime import runtime_contextvar
+
+    runtime = getattr(app, "_runtime", None)
+    if runtime is not None:
+        runtime_contextvar.set(runtime)
+
+    py_scope = _to_py(scope)
+
+    async def py_receive() -> AsgiMessage:
+        js_event = await receive()
+        return _to_py(js_event)
+
+    await app(py_scope, py_receive, send)
+
+
+__all__ = [
+    "call_asgi",
+    "create_app",
+    "run_lifespan_shutdown",
+    "run_lifespan_startup",
+]

--- a/packages/kernel/src/asgi-bridge.test.ts
+++ b/packages/kernel/src/asgi-bridge.test.ts
@@ -1,0 +1,225 @@
+import type { PyodideInterface } from "pyodide";
+import { afterAll, beforeAll, expect, suite, test } from "vitest";
+import { mockPyArrow } from "./mock";
+import { initPyodide } from "./pyodide-loader";
+import {
+  AsgiWebSocketSession,
+  buildWebSocketScope,
+  dispatchHttp,
+  type AsgiApp,
+  type AsgiEvent,
+} from "./asgi-bridge";
+import { getWheelUrls, pyodideUrl } from "./test-utils";
+
+const SPIKE_SCRIPT = `
+import streamlit as st
+
+st.write("Hello from the ASGI spike!")
+`;
+
+suite("ASGI bridge spike", { timeout: 120 * 1000 }, () => {
+  let pyodide: PyodideInterface;
+  let asgiApp: AsgiApp;
+  let lifespanState: unknown;
+
+  beforeAll(async () => {
+    pyodide = await initPyodide(pyodideUrl, {});
+
+    await pyodide.loadPackage("micropip");
+    const micropip = pyodide.pyimport("micropip");
+
+    mockPyArrow(pyodide);
+
+    const wheels = getWheelUrls();
+    // Mirror worker-runtime.ts: pin protobuf >= 7.34.1 ahead of the
+    // streamlit wheel so micropip resolves the PyPI 7.x wheel rather
+    // than falling back to Pyodide's bundled 6.31.1 (Streamlit 1.57.0
+    // gencode requires 7.x).
+    await micropip.install.callKwargs(
+      ["protobuf>=7.34.1,<8", wheels.streamlit, wheels.stliteLib],
+      { keep_going: true },
+    );
+
+    pyodide.FS.writeFile("/spike_app.py", SPIKE_SCRIPT);
+
+    const asgiModule = pyodide.pyimport("stlite_lib.asgi_app");
+    const rawApp = asgiModule.create_app("/spike_app.py");
+    // JS-side scope objects need conversion to Python dicts at the boundary.
+    asgiApp = (scope, receive, send) =>
+      asgiModule.call_asgi(rawApp, scope, receive, send);
+    lifespanState = await asgiModule.run_lifespan_startup(rawApp);
+  });
+
+  afterAll(async () => {
+    if (lifespanState && pyodide) {
+      const { run_lifespan_shutdown } = pyodide.pyimport("stlite_lib.asgi_app");
+      await run_lifespan_shutdown(lifespanState);
+    }
+  });
+
+  test("GET /_stcore/health returns ok", async () => {
+    const response = await dispatchHttp(asgiApp, {
+      method: "GET",
+      path: "/_stcore/health",
+      headers: { host: "stlite.local" },
+      body: "",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const bodyText = new TextDecoder().decode(response.body);
+    expect(bodyText).toBe("ok");
+  });
+
+  test("WebSocket session: BackMsg(rerun) round-trips with ForwardMsg bytes", async () => {
+    // End-to-end WebSocket round-trip through the ASGI bridge:
+    //   1. JS opens the WS (websocket.connect → server accept)
+    //   2. JS sends a rerun BackMsg (the Streamlit frontend's first
+    //      message on every fresh connect)
+    //   3. server runs the script, queues NewSession + element Deltas +
+    //      ScriptFinished via StarletteSessionClient.write_forward_msg
+    //   4. those flow through the background sender task → ASGI send →
+    //      our onServerSend callback as websocket.send events with
+    //      Uint8Array `bytes`
+    // Catching one server-sent bytes event proves the full duplex path.
+    let resolveFirstBytes!: (event: AsgiEvent) => void;
+    let rejectFirstBytes!: (err: Error) => void;
+    const firstBytes = new Promise<AsgiEvent>((resolve, reject) => {
+      resolveFirstBytes = resolve;
+      rejectFirstBytes = reject;
+    });
+
+    let firstBytesSeen = false;
+    const scope = buildWebSocketScope({
+      path: "/_stcore/stream",
+      headers: {
+        host: "stlite.local",
+        origin: "http://stlite.local",
+      },
+    });
+    const session = new AsgiWebSocketSession(asgiApp, scope, (event) => {
+      if (firstBytesSeen) return;
+      if (event.type === "websocket.send" && event.bytes) {
+        firstBytesSeen = true;
+        resolveFirstBytes(event);
+      } else if (event.type === "websocket.close") {
+        rejectFirstBytes(
+          new Error(
+            `WebSocket closed before any bytes arrived (code=${event.code ?? "?"})`,
+          ),
+        );
+      }
+    });
+
+    const subprotocol = await session.start();
+    // No explicit subprotocol negotiation in this minimal scope.
+    expect(subprotocol).toBeNull();
+
+    // Build a rerun BackMsg on the Python side so the test doesn't need
+    // its own protobufjs build. Empty ClientState is enough to request
+    // a fresh script run.
+    const backMsgProxy = pyodide.runPython(`
+from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.ClientState_pb2 import ClientState
+BackMsg(rerun_script=ClientState()).SerializeToString()
+`);
+    const backMsg = backMsgProxy.toJs() as Uint8Array;
+    backMsgProxy.destroy();
+    session.postClientMessage(backMsg);
+
+    const event = await firstBytes;
+    const bytes = event.bytes as Uint8Array;
+    expect(bytes.byteLength).toBeGreaterThan(0);
+
+    await session.close();
+  });
+
+  test("Multi-App: two independent Apps coexist in the same Pyodide process", async () => {
+    // Scoping check for the SharedWorker model (one Pyodide hosting multiple
+    // appIds, each with its own Runtime). Construct two App instances pointing
+    // at distinct scripts, drive both lifespans, then exercise each one over
+    // its own WebSocket. The fact that both sessions independently emit
+    // ForwardMsg bytes proves:
+    //   * App() / Runtime() instances don't collide with each other in one
+    //     Pyodide process (no hidden module-level singletons)
+    //   * call_asgi's per-task `runtime_contextvar.set(app._runtime)` correctly
+    //     dispatches each session's BackMsg to its own Runtime
+    //   * Two ASGI lifespan tasks (one per App) can run side-by-side
+    pyodide.FS.writeFile(
+      "/spike_app_a.py",
+      'import streamlit as st\nst.write("App A")\n',
+    );
+    pyodide.FS.writeFile(
+      "/spike_app_b.py",
+      'import streamlit as st\nst.write("App B")\n',
+    );
+
+    const asgiModule = pyodide.pyimport("stlite_lib.asgi_app");
+    const rawAppA = asgiModule.create_app("/spike_app_a.py");
+    const rawAppB = asgiModule.create_app("/spike_app_b.py");
+
+    const lifespanA = await asgiModule.run_lifespan_startup(rawAppA);
+    const lifespanB = await asgiModule.run_lifespan_startup(rawAppB);
+
+    try {
+      const callA: AsgiApp = (scope, receive, send) =>
+        asgiModule.call_asgi(rawAppA, scope, receive, send);
+      const callB: AsgiApp = (scope, receive, send) =>
+        asgiModule.call_asgi(rawAppB, scope, receive, send);
+
+      const backMsgProxy = pyodide.runPython(`
+from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.ClientState_pb2 import ClientState
+BackMsg(rerun_script=ClientState()).SerializeToString()
+`);
+      const backMsg = backMsgProxy.toJs() as Uint8Array;
+      backMsgProxy.destroy();
+
+      async function runSessionRoundTrip(call: AsgiApp): Promise<Uint8Array> {
+        let resolveBytes!: (b: Uint8Array) => void;
+        let rejectBytes!: (err: Error) => void;
+        const bytesPromise = new Promise<Uint8Array>((resolve, reject) => {
+          resolveBytes = resolve;
+          rejectBytes = reject;
+        });
+
+        let captured = false;
+        const scope = buildWebSocketScope({
+          path: "/_stcore/stream",
+          headers: {
+            host: "stlite.local",
+            origin: "http://stlite.local",
+          },
+        });
+        const session = new AsgiWebSocketSession(call, scope, (event) => {
+          if (captured) return;
+          if (event.type === "websocket.send" && event.bytes) {
+            captured = true;
+            resolveBytes(event.bytes as Uint8Array);
+          } else if (event.type === "websocket.close") {
+            rejectBytes(
+              new Error(
+                `WebSocket closed before bytes (code=${event.code ?? "?"})`,
+              ),
+            );
+          }
+        });
+        await session.start();
+        session.postClientMessage(backMsg);
+        const bytes = await bytesPromise;
+        await session.close();
+        return bytes;
+      }
+
+      const [bytesA, bytesB] = await Promise.all([
+        runSessionRoundTrip(callA),
+        runSessionRoundTrip(callB),
+      ]);
+
+      expect(bytesA.byteLength).toBeGreaterThan(0);
+      expect(bytesB.byteLength).toBeGreaterThan(0);
+    } finally {
+      await asgiModule.run_lifespan_shutdown(lifespanA);
+      await asgiModule.run_lifespan_shutdown(lifespanB);
+    }
+  });
+});

--- a/packages/kernel/src/asgi-bridge.ts
+++ b/packages/kernel/src/asgi-bridge.ts
@@ -1,0 +1,281 @@
+/**
+ * ASGI bridge for driving Streamlit's Starlette app from the JS worker.
+ *
+ * Replaces the legacy stlite_lib.server.Server emulation: instead of routing
+ * HTTP/WebSocket through a hand-rolled server, we pass an ASGI `scope` plus
+ * async `receive`/`send` callables straight into Streamlit's upstream
+ * Starlette ASGI application.
+ *
+ * The shape mirrors gradio-lite's webworker/asgi.ts (specifically
+ * `makeAsgiRequest`, originally written by whitphx):
+ * https://github.com/gradio-app/gradio-lite/blob/main/js/wasm/src/webworker/asgi.ts
+ *
+ * ASGI spec: https://asgi.readthedocs.io/en/latest/specs/main.html
+ */
+import type { PyProxy } from "pyodide/ffi";
+import type { HttpRequest, HttpResponse } from "./types";
+
+/** ASGI server-info type. The values reflect what we, the "server", advertise. */
+const ASGI_VERSION = { version: "3.0", spec_version: "2.3" } as const;
+const HTTP_VERSION = "1.1";
+
+/** ASGI event shape: `{type: ..., ...}` with arbitrary additional keys. */
+export type AsgiEvent = Record<string, unknown> & { type: string };
+
+/** Async generator-style queue: producers `enqueue`, consumer awaits `dequeue`. */
+export class AwaitableQueue<T> {
+  private items: T[] = [];
+  private waiters: Array<(value: T) => void> = [];
+
+  enqueue(item: T): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(item);
+    } else {
+      this.items.push(item);
+    }
+  }
+
+  dequeue(): Promise<T> {
+    const item = this.items.shift();
+    if (item !== undefined) {
+      return Promise.resolve(item);
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+}
+
+/**
+ * An ASGI application as called from JS. Pyodide returns a `PyProxy` for the
+ * Python `App` instance; calling it as a function dispatches to `App.__call__`,
+ * which returns a Python coroutine. The `PyProxy` for that coroutine is
+ * awaitable from JS.
+ */
+export type AsgiApp = (
+  scope: AsgiEvent,
+  receive: () => Promise<AsgiEvent>,
+  send: (event: AsgiEvent | PyProxy) => Promise<void>,
+) => Promise<unknown> | PyProxy;
+
+/** ASGI HTTP scope. */
+function buildHttpScope(request: HttpRequest): AsgiEvent {
+  const url = new URL(request.path, "http://stlite.local");
+  const headerEntries: Array<[Uint8Array, Uint8Array]> = Object.entries(
+    request.headers,
+  ).map(([name, value]) => [
+    new TextEncoder().encode(name.toLowerCase()),
+    new TextEncoder().encode(value),
+  ]);
+
+  return {
+    type: "http",
+    asgi: ASGI_VERSION,
+    http_version: HTTP_VERSION,
+    method: request.method.toUpperCase(),
+    scheme: "http",
+    path: url.pathname,
+    raw_path: new TextEncoder().encode(url.pathname),
+    query_string: new TextEncoder().encode(url.search.replace(/^\?/, "")),
+    root_path: "",
+    headers: headerEntries,
+    client: ["stlite", 0],
+    server: ["stlite", 80],
+  };
+}
+
+function bodyToBytes(body: HttpRequest["body"]): Uint8Array {
+  if (typeof body === "string") {
+    return new TextEncoder().encode(body);
+  }
+  return new Uint8Array(body);
+}
+
+/** Convert an event sent by the Python side (PyProxy) into a plain JS dict.
+ *
+ * We deliberately don't call ``proxy.destroy()``: Pyodide's automatic GC
+ * (FinalizationRegistry) reclaims it, and double-destroying the same handle
+ * surfaces as "Object has already been destroyed" the next time Pyodide
+ * tries to register or release the proxy.
+ */
+function normalizeSendEvent(event: AsgiEvent | PyProxy): AsgiEvent {
+  if (event && typeof (event as PyProxy).toJs === "function") {
+    const proxy = event as PyProxy;
+    return proxy.toJs({ dict_converter: Object.fromEntries }) as AsgiEvent;
+  }
+  return event as AsgiEvent;
+}
+
+/**
+ * Dispatch a single HTTP request through an ASGI app and resolve with the
+ * collected response.
+ */
+export async function dispatchHttp(
+  asgiApp: AsgiApp,
+  request: HttpRequest,
+): Promise<HttpResponse> {
+  const scope = buildHttpScope(request);
+  const bodyBytes = bodyToBytes(request.body);
+
+  let bodySent = false;
+  const receive = async (): Promise<AsgiEvent> => {
+    if (bodySent) {
+      // Once the request body is drained, ASGI servers send disconnect.
+      return { type: "http.disconnect" };
+    }
+    bodySent = true;
+    return {
+      type: "http.request",
+      body: bodyBytes,
+      more_body: false,
+    };
+  };
+
+  let statusCode = 0;
+  const responseHeaders = new Headers();
+  const responseChunks: Uint8Array[] = [];
+
+  const send = async (rawEvent: AsgiEvent | PyProxy): Promise<void> => {
+    const event = normalizeSendEvent(rawEvent);
+    if (event.type === "http.response.start") {
+      statusCode = (event.status as number) ?? 0;
+      const headers = (event.headers as Array<[Uint8Array, Uint8Array]>) ?? [];
+      for (const [name, value] of headers) {
+        responseHeaders.append(decodeBytes(name), decodeBytes(value));
+      }
+    } else if (event.type === "http.response.body") {
+      const chunk = event.body as Uint8Array | undefined;
+      if (chunk && chunk.byteLength > 0) {
+        responseChunks.push(chunk);
+      }
+    }
+  };
+
+  await asgiApp(scope, receive, send);
+
+  const totalLength = responseChunks.reduce((n, c) => n + c.byteLength, 0);
+  const body = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of responseChunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { statusCode, headers: responseHeaders, body };
+}
+
+/** WebSocket scope helper. */
+export interface WebSocketScopeOptions {
+  path: string;
+  headers?: Record<string, string>;
+  subprotocols?: string[];
+}
+
+export function buildWebSocketScope(options: WebSocketScopeOptions): AsgiEvent {
+  const url = new URL(options.path, "ws://stlite.local");
+  const headerEntries: Array<[Uint8Array, Uint8Array]> = Object.entries(
+    options.headers ?? {},
+  ).map(([name, value]) => [
+    new TextEncoder().encode(name.toLowerCase()),
+    new TextEncoder().encode(value),
+  ]);
+
+  return {
+    type: "websocket",
+    asgi: ASGI_VERSION,
+    http_version: HTTP_VERSION,
+    scheme: "ws",
+    path: url.pathname,
+    raw_path: new TextEncoder().encode(url.pathname),
+    query_string: new TextEncoder().encode(url.search.replace(/^\?/, "")),
+    root_path: "",
+    headers: headerEntries,
+    client: ["stlite", 0],
+    server: ["stlite", 80],
+    subprotocols: options.subprotocols ?? [],
+  };
+}
+
+/**
+ * Wraps an active ASGI WebSocket session. JS owns the channel; the ASGI app
+ * runs in the background, draining `receive()` and pushing into `send()`.
+ *
+ * Lifecycle:
+ *   1. Construct → start() returns once the app sends `websocket.accept`.
+ *   2. send / postClientMessage as needed.
+ *   3. close() → emits `websocket.disconnect`, awaits the app task.
+ */
+export class AsgiWebSocketSession {
+  private receiveQueue = new AwaitableQueue<AsgiEvent>();
+  private acceptedResolve!: (subprotocol: string | null) => void;
+  private acceptedReject!: (err: Error) => void;
+  private acceptedPromise: Promise<string | null>;
+  private appTask: Promise<unknown> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly asgiApp: AsgiApp,
+    private readonly scope: AsgiEvent,
+    private readonly onServerSend: (event: AsgiEvent) => void,
+  ) {
+    this.acceptedPromise = new Promise<string | null>((resolve, reject) => {
+      this.acceptedResolve = resolve;
+      this.acceptedReject = reject;
+    });
+  }
+
+  start(): Promise<string | null> {
+    this.receiveQueue.enqueue({ type: "websocket.connect" });
+
+    const receive = (): Promise<AsgiEvent> => this.receiveQueue.dequeue();
+    const send = async (rawEvent: AsgiEvent | PyProxy): Promise<void> => {
+      const event = normalizeSendEvent(rawEvent);
+      if (event.type === "websocket.accept") {
+        this.acceptedResolve((event.subprotocol as string | null) ?? null);
+        return;
+      }
+      if (event.type === "websocket.close" && !this.closed) {
+        this.acceptedReject(
+          new Error(
+            `WebSocket closed before accept (code=${event.code ?? "?"})`,
+          ),
+        );
+      }
+      this.onServerSend(event);
+    };
+
+    const result = this.asgiApp(this.scope, receive, send);
+    this.appTask = Promise.resolve(result as Promise<unknown>);
+    this.appTask.catch((err) => {
+      this.acceptedReject(err as Error);
+    });
+    return this.acceptedPromise;
+  }
+
+  postClientMessage(payload: Uint8Array | string): void {
+    if (this.closed) return;
+    const event: AsgiEvent =
+      typeof payload === "string"
+        ? { type: "websocket.receive", text: payload }
+        : { type: "websocket.receive", bytes: payload };
+    this.receiveQueue.enqueue(event);
+  }
+
+  async close(code = 1000): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.receiveQueue.enqueue({ type: "websocket.disconnect", code });
+    if (this.appTask) {
+      try {
+        await this.appTask;
+      } catch {
+        // Disconnect-driven errors are expected.
+      }
+    }
+  }
+}
+
+function decodeBytes(bytes: Uint8Array): string {
+  return new TextDecoder("utf-8").decode(bytes);
+}


### PR DESCRIPTION
## Summary

Spike for replacing stlite's hand-rolled HTTP/WS server emulation
(`stlite_lib.server.Server`) with a direct ASGI bridge to upstream
Streamlit 1.57+'s Starlette app (`streamlit.web.server.starlette.starlette_app.App`).

- The JS worker constructs an ASGI `scope` and supplies async
  `receive`/`send` callables; Python's `App.__call__(scope, receive, send)`
  runs upstream's HTTP/WS routing untouched.
- Patterned after gradio-lite's [`makeAsgiRequest`](https://github.com/gradio-app/gradio-lite/blob/145414def99e8aeca0756e89a0f33621d1defb67/js/wasm/src/webworker/asgi.ts).

**Paired with: [whitphx/streamlit#25](https://github.com/whitphx/streamlit/pull/25)** — the streamlit-side change that makes `streamlit.web.server.starlette.*` ship in the stlite wheel.

## What lands here (parent repo)

- `packages/kernel/src/asgi-bridge.ts` — `AwaitableQueue<T>`,
  `dispatchHttp(app, request)`, `AsgiWebSocketSession` (start /
  postClientMessage / close), HTTP + WebSocket scope builders.
- `packages/kernel/src/asgi-bridge.test.ts` — end-to-end vitest that
  boots Pyodide, installs wheels, drives ASGI lifespan startup, hits
  `GET /_stcore/health` (200 "ok"), and completes the WebSocket
  handshake to `/_stcore/stream`.
- `packages/kernel/py/stlite-lib/stlite_lib/asgi_app.py` —
  `create_app(script_path)`, `run_lifespan_startup` /
  `run_lifespan_shutdown`, plus `call_asgi(app, scope, receive, send)`
  as the JS↔Python boundary adapter (JsProxy → dict, memoryview → bytes).
- Submodule pointer bump to pick up whitphx/streamlit#25.

## What's explicitly out of scope

Replacing `bootstrapServer` in `worker-runtime.ts`. The bridge
primitives are in place; production integration (deleting
`stlite_lib.server.*` and wiring all worker messages through this
bridge) is the next PR after the design is approved.

## Test plan

- [x] `cd packages/kernel && yarn vitest run src/asgi-bridge.test.ts` — both tests green
- [ ] Review the ASGI scope-building helpers against the spec
- [ ] Sanity-check the `call_asgi` Python adapter handles all the boundary conversions we need (currently: dict + memoryview→bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)