### PR TITLE
worker-runtime: route HTTP/WS through the ASGI bridge

### DIFF
--- a/packages/kernel/py/stlite-lib/stlite_lib/asgi_app.py
+++ b/packages/kernel/py/stlite-lib/stlite_lib/asgi_app.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Awaitable, Callable, MutableMapping
 
-    from streamlit.web.server.starlette.starlette_app import App
+    from streamlit.starlette import App
 
     AsgiMessage = MutableMapping[str, Any]
 
@@ -28,9 +28,13 @@ def create_app(script_path: str) -> App:
 
     The returned object is callable as ``await app(scope, receive, send)``.
     """
-    # Imported lazily so a stlite worker that never reaches the ASGI path
-    # (e.g. an early boot failure) doesn't pay the import cost.
-    from streamlit.web.server.starlette.starlette_app import App
+    # Use upstream's public re-export (``streamlit.starlette.App``,
+    # documented in starlette_app.App's docstring) rather than the
+    # internal ``streamlit.web.server.starlette.starlette_app`` path.
+    # Imported inside the function purely to keep the dependency close
+    # to its use; importing ``streamlit`` itself already loads App via
+    # ``streamlit/__init__.py``, so there's no extra cost.
+    from streamlit.starlette import App
 
     return App(script_path)
 
@@ -142,6 +146,7 @@ async def call_asgi(
     scope: Any,
     receive: Any,
     send: Any,
+    home_dir: str | None = None,
 ) -> None:
     """Call an ASGI app with scope/receive/send originating from JS.
 
@@ -149,23 +154,34 @@ async def call_asgi(
     can use the standard ASGI accessors. ``send`` is passed through —
     the JS-side ``send`` handler already accepts JsProxy events.
 
-    Each call also binds ``streamlit.runtime.runtime_contextvar`` to the
-    App's runtime instance. The Streamlit script runner and several
-    runtime helpers fetch it via ``Runtime.get_instance()``; without
-    this binding the script execution task spawned during request
-    handling raises ``Exception: Runtime instance not created yet``.
-    Setting it here (not in run_lifespan_startup) is intentional: each
-    JS→Python ASGI call lands in a fresh Pyodide asyncio task whose
-    context doesn't inherit the value bound in the lifespan task, so
-    we need to re-bind on every entry. The PEP 567 contextvar set then
-    propagates to any task the request handler spawns (e.g. the script
-    runner coroutine).
+    Each call also binds two contextvars:
+
+    * ``streamlit.runtime.runtime_contextvar`` to the App's runtime
+      instance. The Streamlit script runner and several runtime helpers
+      fetch it via ``Runtime.get_instance()``; without this binding the
+      script execution task spawned during request handling raises
+      ``Exception: Runtime instance not created yet``.
+    * ``stlite_lib.server.task_context.home_dir_contextvar`` (when
+      ``home_dir`` is provided) so the SharedWorker multi-app CWD
+      machinery (DirectorySyncCoroutineProxy) restores the correct
+      per-app working directory before every script-runner tick.
+
+    Setting these here (not in run_lifespan_startup) is intentional:
+    each JS→Python ASGI call lands in a fresh Pyodide asyncio task
+    whose context doesn't inherit the lifespan task's bindings, so we
+    re-bind on every entry. The PEP 567 contextvar sets then propagate
+    to any task the request handler spawns (e.g. the script runner
+    coroutine).
     """
     from streamlit.runtime import runtime_contextvar
+
+    from stlite_lib.server.task_context import home_dir_contextvar
 
     runtime = getattr(app, "_runtime", None)
     if runtime is not None:
         runtime_contextvar.set(runtime)
+    if home_dir is not None:
+        home_dir_contextvar.set(home_dir)
 
     py_scope = _to_py(scope)
 
@@ -176,9 +192,56 @@ async def call_asgi(
     await app(py_scope, py_receive, send)
 
 
+def make_call_asgi(
+    app: App, home_dir: str | None = None
+) -> Callable[[Any, Any, Any], Awaitable[None]]:
+    """Bind an ``App`` (and optional per-app ``home_dir``) into an ASGI callable.
+
+    Returns an ``async def (scope, receive, send) -> None`` that the JS
+    side can pass to ``dispatchHttp`` / ``AsgiWebSocketSession`` directly
+    without re-supplying the app reference on every call.
+    """
+
+    async def bound(scope: Any, receive: Any, send: Any) -> None:
+        await call_asgi(app, scope, receive, send, home_dir=home_dir)
+
+    return bound
+
+
+def bind_runtime_to_current_context(app: App) -> None:
+    """Set ``runtime_contextvar`` to ``app._runtime`` in the calling context.
+
+    Most ASGI traffic goes through :func:`call_asgi`, which binds the
+    contextvar per-call inside its own asyncio task. But some non-ASGI
+    paths reach for ``Runtime.get_instance()`` outside any call_asgi
+    invocation — most notably ``streamlit.testing.v1.AppTest``'s script
+    runner, which is used by stlite's kernel tests. Those run in tasks
+    that inherit the *shared module context* current at task-creation
+    time, so we need a synchronous JS-callable hook that sets the
+    contextvar there.
+
+    Call this from sync Python (e.g., JS → Python sync call after
+    :func:`run_lifespan_startup`); it must NOT be invoked from within
+    an asyncio task, because PEP 567 isolates contextvar mutations to
+    the task they happen in.
+
+    In multi-app SharedWorker mode the last bind wins for non-ASGI
+    paths — same behavior as the legacy ``stlite_lib.server.Server``
+    flow, which set the contextvar in every ``Server.__init__``.
+    """
+    from streamlit.runtime import runtime_contextvar
+
+    runtime = getattr(app, "_runtime", None)
+    if runtime is None:
+        raise RuntimeError("App._runtime is not set; call run_lifespan_startup first.")
+    runtime_contextvar.set(runtime)
+
+
 __all__ = [
+    "bind_runtime_to_current_context",
     "call_asgi",
     "create_app",
+    "make_call_asgi",
     "run_lifespan_shutdown",
     "run_lifespan_startup",
 ]

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -1,7 +1,7 @@
 /// <reference lib="WebWorker" />
 
 import type { PackageData, PyodideInterface } from "pyodide";
-import type { PyProxy, PyBuffer } from "pyodide/ffi";
+import type { PyProxy } from "pyodide/ffi";
 import {
   resolveAppPath,
   getAppHomeDir,
@@ -23,6 +23,13 @@ import type {
   ModuleAutoLoadMessage,
 } from "./types";
 import { getCodeCompletions } from "./code_completion";
+import {
+  AsgiWebSocketSession,
+  buildWebSocketScope,
+  dispatchHttp,
+  type AsgiApp,
+  type AsgiEvent,
+} from "./asgi-bridge";
 
 export type PostMessageFn = (
   message: OutMessage,
@@ -421,11 +428,20 @@ __setup_script_finished_callback__`); // This last line evaluates to the functio
   };
 }
 
-async function bootstrapServer(
+interface AsgiAppHandle {
+  /** ASGI callable bound to the App + per-app home_dir, suitable for
+   * dispatchHttp / AsgiWebSocketSession. */
+  asgiApp: AsgiApp;
+  /** Opaque state returned by run_lifespan_startup; must be passed to
+   * run_lifespan_shutdown when tearing down. */
+  lifespanState: PyProxy;
+}
+
+async function bootstrapApp(
   pyodide: PyodideInterface,
   appId: string | undefined,
   entrypoint: string,
-) {
+): Promise<AsgiAppHandle> {
   const canonicalEntrypoint = resolveAppPath(appId, entrypoint);
 
   // The code below is based on streamlit.web.cli.main_run().
@@ -434,16 +450,38 @@ async function bootstrapServer(
   prepare(canonicalEntrypoint, []);
   console.debug("Prepared the Streamlit environment");
 
-  console.debug("Booting up the Streamlit server");
-  const Server = pyodide.pyimport("stlite_lib.server.Server");
-  const httpServer = Server(
-    canonicalEntrypoint,
+  console.debug("Booting up the Streamlit ASGI app");
+  const asgiModule = pyodide.pyimport("stlite_lib.asgi_app");
+  const rawApp = asgiModule.create_app(canonicalEntrypoint);
+  const lifespanState = (await asgiModule.run_lifespan_startup(
+    rawApp,
+  )) as PyProxy;
+  // Bind runtime_contextvar in the shared JS-call context so non-ASGI
+  // paths (notably streamlit.testing.v1.AppTest, which the kernel test
+  // suite uses) can reach the runtime via Runtime.get_instance(). ASGI
+  // traffic doesn't depend on this — call_asgi rebinds per request.
+  // Must run synchronously from JS (not awaited) so the set lands in
+  // the shared module context, not a task-local one.
+  asgiModule.bind_runtime_to_current_context(rawApp);
+  // make_call_asgi binds the App + home_dir into a single ASGI callable so
+  // the JS side doesn't have to re-supply them on every dispatch (one
+  // callable per app, reused across requests).
+  const asgiApp = asgiModule.make_call_asgi(
+    rawApp,
     appId ? getAppHomeDir(appId) : undefined,
-  );
-  await httpServer.start();
-  console.debug("Booted up the Streamlit server");
+  ) as unknown as AsgiApp;
+  console.debug("Booted up the Streamlit ASGI app");
 
-  return httpServer;
+  return { asgiApp, lifespanState };
+}
+
+async function shutdownApp(
+  pyodide: PyodideInterface,
+  handle: AsgiAppHandle,
+): Promise<void> {
+  const { run_lifespan_shutdown } = pyodide.pyimport("stlite_lib.asgi_app");
+  await run_lifespan_shutdown(handle.lifespanState);
+  handle.lifespanState.destroy();
 }
 
 export function startWorkerEnv(
@@ -499,7 +537,8 @@ export function startWorkerEnv(
 
   let pyodideReadyPromise: ReturnType<typeof loadPyodideAndPackages> | null =
     null;
-  let serverReadyPromise: ReturnType<typeof bootstrapServer> | null = null;
+  let appReadyPromise: Promise<AsgiAppHandle> | null = null;
+  let wsSession: AsgiWebSocketSession | null = null;
 
   /**
    * Process a message sent to the worker.
@@ -529,12 +568,8 @@ export function startWorkerEnv(
       pyodideReadyPromise
         .then(({ pyodide }) => {
           onProgress("Booting up the Streamlit server.");
-          serverReadyPromise = bootstrapServer(
-            pyodide,
-            appId,
-            initData.entrypoint,
-          );
-          return serverReadyPromise;
+          appReadyPromise = bootstrapApp(pyodide, appId, initData.entrypoint);
+          return appReadyPromise;
         })
         .then(() => {
           postMessage({
@@ -556,8 +591,8 @@ export function startWorkerEnv(
     if (!pyodideReadyPromise) {
       throw new Error("Pyodide initialization has not been started yet.");
     }
-    if (!serverReadyPromise) {
-      throw new Error("Streamlit server has not been started yet.");
+    if (!appReadyPromise) {
+      throw new Error("Streamlit ASGI app has not been started yet.");
     }
     const v = await pyodideReadyPromise;
     const pyodide = v.pyodide;
@@ -565,11 +600,37 @@ export function startWorkerEnv(
     const jedi = v.jedi;
     const { moduleAutoLoad } = v.initData;
 
-    const httpServer = await serverReadyPromise;
+    let appHandle = await appReadyPromise;
 
     const messagePort = event.ports[0];
     function reply(message: ReplyMessage): void {
       messagePort.postMessage(message);
+    }
+
+    function forwardWebsocketEventToClient(event: AsgiEvent): void {
+      if (event.type !== "websocket.send") {
+        // websocket.close events are observed when the server tears down;
+        // we don't currently surface them to the client.
+        return;
+      }
+      const bytes = event.bytes as Uint8Array | undefined;
+      if (bytes) {
+        // Transfer the underlying ArrayBuffer to the main thread to avoid a
+        // structured-clone copy (mirrors the legacy on_message path that
+        // did messageProxy.toJs() and then transferred `.buffer`).
+        // bytes always owns a regular ArrayBuffer (not SharedArrayBuffer)
+        // since it came from Pyodide's memoryview → Uint8Array bridge.
+        const ab = bytes.buffer.slice(
+          bytes.byteOffset,
+          bytes.byteOffset + bytes.byteLength,
+        ) as ArrayBuffer;
+        postMessage({ type: "websocket:message", data: { payload: ab } }, [ab]);
+        return;
+      }
+      const text = event.text as string | undefined;
+      if (typeof text === "string") {
+        postMessage({ type: "websocket:message", data: { payload: text } });
+      }
     }
 
     try {
@@ -579,12 +640,16 @@ export function startWorkerEnv(
 
           const { entrypoint } = msg.data;
 
-          httpServer.stop();
+          if (wsSession) {
+            await wsSession.close();
+            wsSession = null;
+          }
+          await shutdownApp(pyodide, appHandle);
 
-          console.debug("Booting up the Streamlit server");
-          serverReadyPromise = bootstrapServer(pyodide, appId, entrypoint);
-          await serverReadyPromise;
-          console.debug("Booted up the Streamlit server");
+          console.debug("Booting up the Streamlit ASGI app");
+          appReadyPromise = bootstrapApp(pyodide, appId, entrypoint);
+          appHandle = await appReadyPromise;
+          console.debug("Booted up the Streamlit ASGI app");
 
           reply({
             type: "reply",
@@ -596,48 +661,29 @@ export function startWorkerEnv(
 
           const { path } = msg.data;
 
-          httpServer.start_websocket(
-            path,
-            (message: PyBuffer | string, binary: boolean) => {
-              // XXX: Now there is no session mechanism
+          if (wsSession) {
+            // The current kernel only manages one WebSocket per app at a
+            // time. Tear down the previous one before opening a new one.
+            await wsSession.close();
+            wsSession = null;
+          }
 
-              if (binary) {
-                const messageProxy = message as PyBuffer;
-                try {
-                  // We use toJs() rather than getBuffer(). https://pyodide.org/en/stable/usage/type-conversions.html#using-python-buffer-objects-from-javascript
-                  // getBuffer() returns a reference to the Wasm heap memory without copying it,
-                  // but it would be copied to the JS heap when it's transferred to the main thread via `postMessage()` anyway,
-                  // so we choose toJs() for simplicity.
-                  // With toJs(), the buffer is copied to the JS heap,
-                  // and the JS buffer will be transferred to the main thread via `postMessage()` with `[ab]` as the second argument.
-                  const u8 = messageProxy.toJs();
-                  const ab = u8.buffer.slice(
-                    u8.byteOffset,
-                    u8.byteOffset + u8.byteLength,
-                  );
-                  postMessage(
-                    {
-                      type: "websocket:message",
-                      data: {
-                        payload: ab,
-                      },
-                    },
-                    [ab],
-                  );
-                } finally {
-                  messageProxy.destroy();
-                }
-              } else {
-                const messageStr = message as string;
-                postMessage({
-                  type: "websocket:message",
-                  data: {
-                    payload: messageStr,
-                  },
-                });
-              }
+          // The frontend doesn't pass headers on this message; synthesize a
+          // minimal set so Starlette's WS handler accepts the connection.
+          // Origin matches Host → _is_origin_allowed returns true.
+          const scope = buildWebSocketScope({
+            path,
+            headers: {
+              host: "stlite.local",
+              origin: "http://stlite.local",
             },
+          });
+          wsSession = new AsgiWebSocketSession(
+            appHandle.asgiApp,
+            scope,
+            forwardWebsocketEventToClient,
           );
+          await wsSession.start();
 
           reply({
             type: "reply",
@@ -649,7 +695,9 @@ export function startWorkerEnv(
 
           const { payload } = msg.data;
 
-          httpServer.receive_websocket_from_js(payload);
+          if (wsSession) {
+            wsSession.postClientMessage(payload);
+          }
           break;
         }
         case "http:request": {
@@ -657,42 +705,39 @@ export function startWorkerEnv(
 
           const { request } = msg.data;
 
-          const onResponse = (
-            statusCode: number,
-            _headers: PyProxy,
-            _body: PyProxy,
-          ) => {
-            const headersJs = _headers.toJs();
-            // Pyodide may convert Python dicts to Map, LiteralMap, or plain Object
-            // depending on the version. LiteralMap can't be cloned for postMessage,
-            // and plain Objects are not iterable for the Map constructor.
-            // Use Object.entries() to handle all cases uniformly.
-            const headers =
-              headersJs instanceof Map
-                ? new Map<string, string>(headersJs)
-                : new Map<string, string>(Object.entries(headersJs));
-            const body = _body.toJs();
-            console.debug({ statusCode, headers, body });
-
-            reply({
-              type: "http:response",
-              data: {
-                response: {
-                  statusCode,
-                  headers,
-                  body,
+          dispatchHttp(appHandle.asgiApp, {
+            ...request,
+            path: decodeURIComponent(request.path),
+          })
+            .then((response) => {
+              reply({
+                type: "http:response",
+                data: {
+                  response: {
+                    statusCode: response.statusCode,
+                    headers: new Map(response.headers.entries()),
+                    body: response.body,
+                  },
                 },
-              },
+              });
+            })
+            .catch((error) => {
+              console.error("http:request dispatch failed", error);
+              reply({
+                type: "http:response",
+                data: {
+                  response: {
+                    statusCode: 500,
+                    headers: new Map([
+                      ["content-type", "text/plain; charset=utf-8"],
+                    ]),
+                    body: new TextEncoder().encode(
+                      `Internal server error: ${String(error)}`,
+                    ),
+                  },
+                },
+              });
             });
-          };
-
-          httpServer.receive_http_from_js(
-            request.method,
-            decodeURIComponent(request.path),
-            request.headers,
-            request.body,
-            onResponse,
-          );
           break;
         }
         case "file:write": {


### PR DESCRIPTION
## Summary

Stacks on top of #2043 (the ASGI bridge spike). Replaces stlite's hand-rolled `stlite_lib.server.Server` HTTP/WS dispatch in `worker-runtime.ts` with direct ASGI calls into upstream Streamlit's Starlette app.

## The translation

| Old (`stlite_lib.server.Server`) | New (ASGI bridge) |
|---|---|
| `bootstrapServer()` | `bootstrapApp()` → `create_app` → `run_lifespan_startup` → `bind_runtime_to_current_context` → `make_call_asgi` |
| `httpServer.receive_http_from_js(...)` | `dispatchHttp(asgiApp, request)` |
| `httpServer.start_websocket(path, on_message)` + `receive_websocket_from_js(payload)` | `new AsgiWebSocketSession(asgiApp, scope, forwardWebsocketEventToClient).start()` + `session.postClientMessage(payload)` |
| `httpServer.stop()` (reboot) | `shutdownApp(handle)` |

## Bridge module additions (`stlite_lib/asgi_app.py`)

- `call_asgi(..., home_dir=None)` — now binds `home_dir_contextvar` alongside `runtime_contextvar` so the `DirectorySyncCoroutineProxy` restores the correct CWD per request.
- `make_call_asgi(app, home_dir)` — partial-bind factory so JS holds one ASGI callable per app instead of re-supplying `app` + `home_dir` on every dispatch.
- `bind_runtime_to_current_context(app)` — sync hook called from JS right after `run_lifespan_startup`. The legacy `Server.__init__` was synchronous and set `runtime_contextvar` in the shared module context, so non-ASGI paths like `streamlit.testing.v1.AppTest` (used by the kernel test suite) inherited the binding via PEP 567 copy-on-task-create. This helper restores that behavior — `call_asgi`'s per-call bind handles ASGI traffic correctly but doesn't reach `AppTest`'s script runner task. In multi-app SharedWorker mode the last bind wins for non-ASGI paths (same as the legacy Server, since multiple `Server.__init__` calls also overwrote the global var).

## What's explicitly out of scope

- **Deleting `stlite_lib.server.{server, *_handler, server_util, httputil}`** (~600 LOC). All unreached by the kernel now; intentional follow-up so this PR stays focused on the routing switch. `task_context.py` stays either way — upstream's `script_runner.py` and the test harness both import its `DirectorySyncCoroutineProxy` / `home_dir_contextvar`.
- **Moving `task_context.py` out of `stlite_lib.server.*`** — the path reads misleadingly now (no Server in there), but renaming touches another patch on the streamlit submodule (`script_runner.py:316`) and the test file. Cleanup PR territory.

## Test plan

- [x] `make kernel` exits clean
- [x] Kernel vitest: 87/87 pass — single-app, SharedWorker multi-app, sample apps, HTTP/WS round-trips, "CWD per app" test, and the spike tests on top
- [x] `cd packages/kernel/py/stlite-lib && uv run pytest` — 66/66 pass (the legacy Server tests still cover the now-dead module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)