### PR TITLE
fix(kernel): skip checkSourceUrlResponse for stlite.invalid URLs

### DIFF
--- a/.changeset/silence-stlite-invalid-source-fetch.md
+++ b/.changeset/silence-stlite-invalid-source-fetch.md
@@ -1,0 +1,5 @@
+---
+"@stlite/kernel": patch
+---
+
+Silence the `ERR_NAME_NOT_RESOLVED` console errors that appear when Custom Components, Video subtitles, or Download Button assets are rendered. Upstream Streamlit's `DefaultStreamlitEndpoints.checkSourceUrlResponse` issues a side-effect `fetch()` against the source URL purely to surface 4xx/5xx responses to the embedding host; for stlite-bridged URLs (which use the `stlite.invalid` sentinel host) that fetch can never resolve and produces noisy console + host-error output without any useful signal. Rendering itself is unaffected — it already routes through the kernel's worker bridge.

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ $(kernel): $(shell \
 kernel-test: $(shell \
 	find packages/kernel/src -type f \( -name "*.ts" -o -name "*.tsx" \); \
 	find packages/kernel -maxdepth 1 -type f \( -name "package.json" -o -name "tsconfig*.json" -o -name "vitest.config.ts" \); \
-) $(common) $(stlite-lib-wheel) $(streamlit_wheel)
+) $(common) $(stlite-lib-wheel) $(streamlit_wheel) $(streamlit-frontend-lib)
 	cd packages/kernel; \
 	yarn test
 

--- a/packages/kernel/src/react-helpers/endpoints-patch.spec.ts
+++ b/packages/kernel/src/react-helpers/endpoints-patch.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { DefaultStreamlitEndpoints } from "@streamlit/connection";
+import "./endpoints-patch";
+
+function makeEndpoints(): DefaultStreamlitEndpoints {
+  const sendClientError = vi.fn();
+  return new DefaultStreamlitEndpoints({
+    getServerUri: () => undefined,
+    csrfEnabled: false,
+    sendClientError,
+  });
+}
+
+describe("checkSourceUrlResponse patch", () => {
+  let fetchMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, "fetch");
+  });
+
+  it("skips fetch and sendClientError for stlite.invalid URLs", async () => {
+    const endpoints = makeEndpoints();
+    const sendClientError = vi.spyOn(endpoints, "sendClientErrorToHost");
+
+    await endpoints.checkSourceUrlResponse(
+      "https://stlite.invalid/component/pkg.comp/index.html?streamlitUrl=https%3A%2F%2Fexample.com%2F",
+      "ComponentRegistry",
+      "pkg.comp",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sendClientError).not.toHaveBeenCalled();
+  });
+
+  it("falls through to fetch for non-stlite hosts", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("", { status: 200, statusText: "OK" }),
+    );
+    const endpoints = makeEndpoints();
+    const sendClientError = vi.spyOn(endpoints, "sendClientErrorToHost");
+
+    await endpoints.checkSourceUrlResponse(
+      "https://components.example.com/index.html",
+      "ComponentRegistry",
+      "pkg.comp",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://components.example.com/index.html",
+    );
+    expect(sendClientError).not.toHaveBeenCalled();
+  });
+
+  it("reports non-OK responses for non-stlite hosts (upstream behavior preserved)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("", { status: 404, statusText: "Not Found" }),
+    );
+    const endpoints = makeEndpoints();
+    const sendClientError = vi.spyOn(endpoints, "sendClientErrorToHost");
+
+    await endpoints.checkSourceUrlResponse(
+      "https://components.example.com/missing.html",
+      "ComponentRegistry",
+      "pkg.comp",
+    );
+
+    expect(sendClientError).toHaveBeenCalledTimes(1);
+    expect(sendClientError).toHaveBeenCalledWith(
+      "ComponentRegistry",
+      404,
+      "Not Found",
+      "https://components.example.com/missing.html",
+      "pkg.comp",
+    );
+  });
+
+  it("falls through (does not silently swallow) for malformed URLs", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const endpoints = makeEndpoints();
+    const sendClientError = vi.spyOn(endpoints, "sendClientErrorToHost");
+
+    await endpoints.checkSourceUrlResponse(
+      "not-a-url",
+      "ComponentRegistry",
+      "pkg.comp",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("not-a-url");
+    expect(sendClientError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kernel/src/react-helpers/endpoints-patch.ts
+++ b/packages/kernel/src/react-helpers/endpoints-patch.ts
@@ -1,0 +1,51 @@
+import { DefaultStreamlitEndpoints } from "@streamlit/connection";
+import { getLogger } from "loglevel";
+
+const LOG = getLogger("stlite-endpoints-patch");
+
+// Stlite's ConnectionManager.getBaseUriParts() returns
+// `https://stlite.invalid/` as the server URI so that upstream-built URLs
+// (component, media, etc.) can be intercepted by stlite's in-app worker
+// bridge instead of going to the network. `.invalid` is an RFC 2606 reserved
+// TLD that never resolves. See packages/kernel/src/react-helpers/ConnectionManager.ts.
+const STLITE_INVALID_HOSTNAME = "stlite.invalid";
+
+const originalCheckSourceUrlResponse =
+  DefaultStreamlitEndpoints.prototype.checkSourceUrlResponse;
+
+// Stlite: upstream's `checkSourceUrlResponse` is a side-effect health check
+// that `fetch()`es `sourceUrl` to surface 4xx/5xx (or network) failures to
+// the embedding host. When `sourceUrl` points at our `stlite.invalid`
+// sentinel host (Custom Component index.html, media URLs that haven't been
+// rewritten to a blob URL yet, download URLs, etc.) the fetch *always* fails
+// with `ERR_NAME_NOT_RESOLVED`, polluting the console and the host's
+// client-error stream. The actual rendering already routes through
+// `kernel.sendHttpRequest()` (see `CustomComponentIFrame`, `media.ts`), so
+// the health-check has no useful signal to contribute for these URLs.
+DefaultStreamlitEndpoints.prototype.checkSourceUrlResponse = async function (
+  sourceUrl: string,
+  componentName: string,
+  customComponentName?: string,
+): Promise<void> {
+  let hostname: string | undefined;
+  try {
+    hostname = new URL(sourceUrl).hostname;
+  } catch {
+    // Malformed URL — let upstream handle it so its existing error path
+    // (sendClientErrorToHost) still fires.
+  }
+
+  if (hostname === STLITE_INVALID_HOSTNAME) {
+    LOG.debug(
+      `Skipping checkSourceUrlResponse for stlite-bridged URL: ${sourceUrl}`,
+    );
+    return;
+  }
+
+  return originalCheckSourceUrlResponse.call(
+    this,
+    sourceUrl,
+    componentName,
+    customComponentName,
+  );
+};

--- a/packages/kernel/src/react-helpers/index.ts
+++ b/packages/kernel/src/react-helpers/index.ts
@@ -1,3 +1,5 @@
+import "./endpoints-patch"; // Side effect: monkey-patches upstream DefaultStreamlitEndpoints.
+
 export * from "./ConnectionManager";
 export * from "./media";
 export * from "./download-button";


### PR DESCRIPTION
## Summary

Upstream Streamlit's `DefaultStreamlitEndpoints.checkSourceUrlResponse` issues a `fetch(sourceUrl)` purely as a side-effect health check (to surface 4xx/5xx responses to the embedding host). For URLs built against stlite's `stlite.invalid` sentinel host — Custom Components, Video subtitles, Download Button assets — the fetch can never resolve and produces noisy `ERR_NAME_NOT_RESOLVED` output without any useful signal.

Rendering itself already routes through the kernel's worker bridge (`CustomComponentIFrame`, `media.ts`) so the health check has nothing to contribute for these URLs.

This PR monkey-patches `DefaultStreamlitEndpoints.prototype.checkSourceUrlResponse` at `@stlite/kernel/react` import time (already loaded by upstream's `App.tsx`, `ComponentInstance.tsx`, etc. via the existing fork patches) to:

- No-op for `stlite.invalid` hostnames.
- Fall through to upstream behavior for all other URLs (so non-stlite component URLs, real CDN-hosted assets, etc. still get the health check).

## User-visible effect

Before: `Client Error: <component> fetch error - Failed to fetch` per Custom Component render, Video element with subtitles, or Download Button click.

After: silent for stlite-bridged URLs; identical behavior for real URLs.

## Test plan

- [x] New unit tests in `packages/kernel/src/react-helpers/endpoints-patch.spec.ts` covering: stlite.invalid skip, fall-through to fetch for non-stlite hosts, upstream error-reporting preserved on 404, malformed URL fall-through.
- [x] Existing `packages/kernel/src/react-helpers/*` tests still pass (21/21).
- [x] `corepack yarn cspell` clean.
- [x] `yarn check:lint`, `yarn check:format`, `yarn tsc --noEmit` clean.
- [ ] Manual repro: load a Custom Component app (e.g. `streamlit-folium`) and confirm the console no longer logs `Client Error: ... fetch error - Failed to fetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed spurious console errors when rendering Streamlit Custom Components, video subtitles, and Download Button assets; rendering behavior is unchanged.

* **Tests**
  * Added tests to verify the error-suppression behavior and related URL handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/stlite/pull/2049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->