### PR TITLE
ci: run e2e-browser inside Playwright Docker image

### DIFF
--- a/.changeset/e2e-browser-docker.md
+++ b/.changeset/e2e-browser-docker.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: run the e2e-browser Playwright job inside the official Playwright Docker image (`mcr.microsoft.com/playwright`) so the `yarn install:browsers` step is no longer needed. Sidesteps an intermittent post-download hang in Playwright's `install --with-deps` that had been timing out shards.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,6 +76,21 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # `yarn install:browsers` (i.e. `playwright install --with-deps`)
+    # repeatedly hung post-download on plain ubuntu-latest runners: the
+    # Chromium zip finished in <1s, then ~15min of silence until the step
+    # timeout fired. Running the job inside Playwright's official Docker
+    # image — which ships browsers pre-installed at /ms-playwright with
+    # all system deps already there — sidesteps that install step
+    # entirely. (Same approach as e2e-react below.)
+    #
+    # Image tag must match `@playwright/test` in
+    # packages/browser/e2e-tests/package.json — bump alongside any
+    # Playwright upgrade.
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0
+      options: --ipc=host # Recommended by Playwright for Chromium shared memory.
+
     strategy:
       fail-fast: false
       matrix:
@@ -93,27 +108,11 @@ jobs:
         with:
           node-version-file: ${{ env.node-version-file }}
 
-      # `playwright install` repeatedly hung post-download on GitHub
-      # Actions runners (Chromium zip finishes in <1s, then ~15min of
-      # silence until timeout). Restoring the browser cache makes
-      # `playwright install` a no-op on warm runs and sidesteps the hang
-      # entirely. The key is bound to the resolved `@playwright/test`
-      # version in the lockfile so a Playwright bump invalidates it.
-      - name: Cache Playwright browsers
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/browser/e2e-tests/yarn.lock') }}
-
       - name: Set up the e2e-tests environment
-        # `yarn install` (registry) and `yarn install:browsers` (Playwright CDN)
-        # have intermittently hung in GitHub Actions runners and burned the
-        # whole 6h job timeout. Cap the step so a hang fails fast and the
-        # shard can be rerun.
+        # Cap as a safety net; browsers come from the container image,
+        # so this is just `yarn install`.
         timeout-minutes: 15
-        run: |
-          yarn install
-          yarn install:browsers
+        run: yarn install
         working-directory: packages/browser/e2e-tests
 
       - name: Build demos

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,11 @@ jobs:
         working-directory: packages/browser/e2e-tests
         env:
           BUILD_DIR: ${{ runner.temp }}/artifacts/browser/package/build
+          # Inside the Playwright container we run as root, but GH Actions
+          # overrides $HOME to /github/home (owned by pwuser). Firefox
+          # refuses to launch in that state; restore HOME=/root.
+          # Playwright's own error message points at this exact fix.
+          HOME: /root
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,6 +93,18 @@ jobs:
         with:
           node-version-file: ${{ env.node-version-file }}
 
+      # `playwright install` repeatedly hung post-download on GitHub
+      # Actions runners (Chromium zip finishes in <1s, then ~15min of
+      # silence until timeout). Restoring the browser cache makes
+      # `playwright install` a no-op on warm runs and sidesteps the hang
+      # entirely. The key is bound to the resolved `@playwright/test`
+      # version in the lockfile so a Playwright bump invalidates it.
+      - name: Cache Playwright browsers
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('packages/browser/e2e-tests/yarn.lock') }}
+
       - name: Set up the e2e-tests environment
         # `yarn install` (registry) and `yarn install:browsers` (Playwright CDN)
         # have intermittently hung in GitHub Actions runners and burned the


### PR DESCRIPTION
## Summary

`yarn install:browsers` (i.e. `playwright install --with-deps`) has been repeatedly hanging post-download on plain `ubuntu-latest` runners during the e2e-browser job: the Chromium zip finishes downloading in <1s, then ~15min of total silence until the step timeout fires. Reproduced on multiple recent PR runs.

This PR switches `e2e-browser` to run inside the official `mcr.microsoft.com/playwright` Docker image (the same approach `e2e-react` already uses via its `run-in-docker.sh`). Browsers + system deps are pre-installed at `/ms-playwright`, so the `install:browsers` step becomes unnecessary and the flake disappears.

### Important: image tag pin

The image tag (`v1.57.0`) must match `@playwright/test` in `packages/browser/e2e-tests/package.json`. Bump it alongside any Playwright upgrade.

### History

This PR initially tried caching `~/.cache/ms-playwright` (commit `61e3a9a6`). That didn't help: every shard starts with a cold cache simultaneously, and `actions/cache` only saves on workflow success, so failures don't populate the cache and re-runs don't benefit either. The Docker switch (commit `6b2ff145`) supersedes that. Will be squashed at merge time.

## Test plan

- [x] `actionlint` clean.
- [ ] Verify all 4 e2e-browser shards pass without hitting the install hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * e2e tests now run inside the official Playwright Docker environment, removing the separate browser-install step.
  * CI now performs a single package install, reducing setup time.
  * Added a HOME workaround to prevent container permission issues when running tests.
  * Result: fewer intermittent hangs, faster and more reliable end-to-end test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/stlite/pull/2053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->