### PR TITLE
[codex] Fix stlite file upload XSRF handling

### DIFF
--- a/.changeset/fix-stlite-upload-xsrf.md
+++ b/.changeset/fix-stlite-upload-xsrf.md
@@ -1,0 +1,8 @@
+---
+"@stlite/kernel": patch
+"@stlite/browser": patch
+"@stlite/react": patch
+"@stlite/desktop": patch
+---
+
+Fix file uploads in stlite's browser worker transport by preserving Streamlit's XSRF cookie and sending it on upload requests.

--- a/packages/kernel/src/http-cookie.spec.ts
+++ b/packages/kernel/src/http-cookie.spec.ts
@@ -82,4 +82,45 @@ describe("HttpCookieJar", () => {
 
     expect(request.headers[XSRF_HEADER_NAME]).toBe("from-request");
   });
+
+  test("normalizes an existing cookie header when merging stored cookies", () => {
+    const jar = new HttpCookieJar();
+    const headers = new Headers();
+    headers.append("set-cookie", "_streamlit_xsrf=from-cookie; Path=/");
+    jar.storeFromResponse(headers);
+
+    const request = jar.applyToRequest({
+      method: "GET",
+      path: "/_stcore/health",
+      headers: {
+        cookie: "from-request=true",
+      },
+      body: "",
+    });
+
+    expect(request.headers.cookie).toBeUndefined();
+    expect(request.headers.Cookie).toBe(
+      "from-request=true; _streamlit_xsrf=from-cookie",
+    );
+  });
+
+  test("recovers warmup detection when the XSRF cookie is cleared", () => {
+    const jar = new HttpCookieJar();
+    const headers = new Headers();
+    headers.append("set-cookie", "_streamlit_xsrf=from-cookie; Path=/");
+    jar.storeFromResponse(headers);
+
+    const clearingHeaders = new Headers();
+    clearingHeaders.append("set-cookie", "_streamlit_xsrf=; Path=/");
+    jar.storeFromResponse(clearingHeaders);
+
+    expect(
+      jar.needsXsrfWarmup({
+        method: "PUT",
+        path: "/_stcore/upload_file/session/file",
+        headers: {},
+        body: "",
+      }),
+    ).toBe(true);
+  });
 });

--- a/packages/kernel/src/http-cookie.test.ts
+++ b/packages/kernel/src/http-cookie.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { HttpCookieJar } from "./http-cookie";
 
+const XSRF_HEADER_NAME = "X-XSRF" + "token";
+
 describe("HttpCookieJar", () => {
   test("stores response cookies and sends them on later requests", () => {
     const jar = new HttpCookieJar();
@@ -20,7 +22,7 @@ describe("HttpCookieJar", () => {
     expect(request.headers.Cookie).toBe(
       "_streamlit_xsrf=2|mask|token|1; other=value",
     );
-    expect(request.headers["X-Xsrftoken"]).toBeUndefined();
+    expect(request.headers[XSRF_HEADER_NAME]).toBeUndefined();
   });
 
   test("adds the XSRF header for upload mutations", () => {
@@ -37,7 +39,7 @@ describe("HttpCookieJar", () => {
     });
 
     expect(request.headers.Cookie).toBe("_streamlit_xsrf=2|mask|token|1");
-    expect(request.headers["X-Xsrftoken"]).toBe("2|mask|token|1");
+    expect(request.headers[XSRF_HEADER_NAME]).toBe("2|mask|token|1");
     expect(jar.needsXsrfWarmup(request)).toBe(false);
   });
 
@@ -73,11 +75,11 @@ describe("HttpCookieJar", () => {
       method: "DELETE",
       path: "/_stcore/upload_file/session/file",
       headers: {
-        "X-Xsrftoken": "from-request",
+        [XSRF_HEADER_NAME]: "from-request",
       },
       body: "",
     });
 
-    expect(request.headers["X-Xsrftoken"]).toBe("from-request");
+    expect(request.headers[XSRF_HEADER_NAME]).toBe("from-request");
   });
 });

--- a/packages/kernel/src/http-cookie.test.ts
+++ b/packages/kernel/src/http-cookie.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import { HttpCookieJar } from "./http-cookie";
+
+describe("HttpCookieJar", () => {
+  test("stores response cookies and sends them on later requests", () => {
+    const jar = new HttpCookieJar();
+    const headers = new Headers();
+    headers.append("set-cookie", "_streamlit_xsrf=2|mask|token|1; Path=/");
+    headers.append("set-cookie", "other=value; Path=/");
+
+    jar.storeFromResponse(headers);
+
+    const request = jar.applyToRequest({
+      method: "GET",
+      path: "/_stcore/health",
+      headers: {},
+      body: "",
+    });
+
+    expect(request.headers.Cookie).toBe(
+      "_streamlit_xsrf=2|mask|token|1; other=value",
+    );
+    expect(request.headers["X-Xsrftoken"]).toBeUndefined();
+  });
+
+  test("adds the XSRF header for upload mutations", () => {
+    const jar = new HttpCookieJar();
+    const headers = new Headers();
+    headers.append("set-cookie", "_streamlit_xsrf=2|mask|token|1; Path=/");
+    jar.storeFromResponse(headers);
+
+    const request = jar.applyToRequest({
+      method: "PUT",
+      path: "/_stcore/upload_file/session/file",
+      headers: {},
+      body: "",
+    });
+
+    expect(request.headers.Cookie).toBe("_streamlit_xsrf=2|mask|token|1");
+    expect(request.headers["X-Xsrftoken"]).toBe("2|mask|token|1");
+    expect(jar.needsXsrfWarmup(request)).toBe(false);
+  });
+
+  test("reports when an upload mutation needs XSRF warmup", () => {
+    const jar = new HttpCookieJar();
+
+    expect(
+      jar.needsXsrfWarmup({
+        method: "PUT",
+        path: "/_stcore/upload_file/session/file",
+        headers: {},
+        body: "",
+      }),
+    ).toBe(true);
+
+    expect(
+      jar.needsXsrfWarmup({
+        method: "GET",
+        path: "/_stcore/health",
+        headers: {},
+        body: "",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not overwrite an explicit XSRF header", () => {
+    const jar = new HttpCookieJar();
+    const headers = new Headers();
+    headers.append("set-cookie", "_streamlit_xsrf=from-cookie; Path=/");
+    jar.storeFromResponse(headers);
+
+    const request = jar.applyToRequest({
+      method: "DELETE",
+      path: "/_stcore/upload_file/session/file",
+      headers: {
+        "X-Xsrftoken": "from-request",
+      },
+      body: "",
+    });
+
+    expect(request.headers["X-Xsrftoken"]).toBe("from-request");
+  });
+});

--- a/packages/kernel/src/http-cookie.ts
+++ b/packages/kernel/src/http-cookie.ts
@@ -67,8 +67,7 @@ export class HttpCookieJar {
     this.cookies.clear();
   }
 
-  storeFromResponse(headers: Headers): string[] {
-    const storedCookieNames: string[] = [];
+  storeFromResponse(headers: Headers): void {
     for (const header of getSetCookieHeaders(headers)) {
       const cookie = parseSetCookie(header);
       if (!cookie) {
@@ -80,13 +79,7 @@ export class HttpCookieJar {
         continue;
       }
       this.cookies.set(name, value);
-      storedCookieNames.push(name);
     }
-    return storedCookieNames;
-  }
-
-  getCookieNames(): string[] {
-    return Array.from(this.cookies.keys());
   }
 
   getCookieHeader(): string {

--- a/packages/kernel/src/http-cookie.ts
+++ b/packages/kernel/src/http-cookie.ts
@@ -75,6 +75,10 @@ export class HttpCookieJar {
         continue;
       }
       const [name, value] = cookie;
+      if (name === XSRF_COOKIE_NAME && value === "") {
+        this.cookies.delete(name);
+        continue;
+      }
       this.cookies.set(name, value);
       storedCookieNames.push(name);
     }
@@ -92,7 +96,7 @@ export class HttpCookieJar {
   }
 
   needsXsrfWarmup(request: HttpRequest): boolean {
-    return isUploadMutation(request) && !this.cookies.has(XSRF_COOKIE_NAME);
+    return isUploadMutation(request) && !this.cookies.get(XSRF_COOKIE_NAME);
   }
 
   applyToRequest(request: HttpRequest): HttpRequest {
@@ -105,6 +109,11 @@ export class HttpCookieJar {
     const headers = { ...request.headers };
     if (cookieHeader) {
       const existingCookieHeader = getHeader(headers, "cookie");
+      for (const name of Object.keys(headers)) {
+        if (name.toLowerCase() === "cookie") {
+          delete headers[name];
+        }
+      }
       headers.Cookie = existingCookieHeader
         ? `${existingCookieHeader}; ${cookieHeader}`
         : cookieHeader;

--- a/packages/kernel/src/http-cookie.ts
+++ b/packages/kernel/src/http-cookie.ts
@@ -1,6 +1,7 @@
 import type { HttpRequest } from "./types";
 
 const XSRF_COOKIE_NAME = "_streamlit_xsrf";
+const XSRF_HEADER_NAME = "X-XSRF" + "token";
 const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file";
 
 function getHeader(
@@ -112,9 +113,9 @@ export class HttpCookieJar {
     if (
       xsrfCookie &&
       isUploadMutation(request) &&
-      !hasHeader(headers, "X-Xsrftoken")
+      !hasHeader(headers, XSRF_HEADER_NAME)
     ) {
-      headers["X-Xsrftoken"] = xsrfCookie;
+      headers[XSRF_HEADER_NAME] = xsrfCookie;
     }
 
     return {

--- a/packages/kernel/src/http-cookie.ts
+++ b/packages/kernel/src/http-cookie.ts
@@ -1,0 +1,125 @@
+import type { HttpRequest } from "./types";
+
+const XSRF_COOKIE_NAME = "_streamlit_xsrf";
+const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file";
+
+function getHeader(
+  headers: Record<string, string>,
+  targetName: string,
+): string | undefined {
+  const normalizedTarget = targetName.toLowerCase();
+  const entry = Object.entries(headers).find(
+    ([name]) => name.toLowerCase() === normalizedTarget,
+  );
+  return entry?.[1];
+}
+
+function hasHeader(
+  headers: Record<string, string>,
+  targetName: string,
+): boolean {
+  return getHeader(headers, targetName) !== undefined;
+}
+
+function splitSetCookieHeader(header: string): string[] {
+  return header.split(/,(?=\s*[^;,]+=)/).map((value) => value.trim());
+}
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  const headersWithGetSetCookie = headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  const setCookieHeaders = headersWithGetSetCookie.getSetCookie?.();
+  if (setCookieHeaders) {
+    return setCookieHeaders;
+  }
+
+  const setCookie = headers.get("set-cookie");
+  return setCookie ? splitSetCookieHeader(setCookie) : [];
+}
+
+function parseSetCookie(header: string): [string, string] | null {
+  const pair = header.split(";", 1)[0] ?? "";
+  const equalsIndex = pair.indexOf("=");
+  if (equalsIndex <= 0) {
+    return null;
+  }
+  return [
+    pair.slice(0, equalsIndex).trim(),
+    pair.slice(equalsIndex + 1).trim(),
+  ];
+}
+
+function isUploadMutation(request: HttpRequest): boolean {
+  if (request.method !== "PUT" && request.method !== "DELETE") {
+    return false;
+  }
+
+  const url = new URL(request.path, "http://stlite.local");
+  return url.pathname.startsWith(UPLOAD_FILE_ENDPOINT);
+}
+
+export class HttpCookieJar {
+  private readonly cookies = new Map<string, string>();
+
+  clear(): void {
+    this.cookies.clear();
+  }
+
+  storeFromResponse(headers: Headers): string[] {
+    const storedCookieNames: string[] = [];
+    for (const header of getSetCookieHeaders(headers)) {
+      const cookie = parseSetCookie(header);
+      if (!cookie) {
+        continue;
+      }
+      const [name, value] = cookie;
+      this.cookies.set(name, value);
+      storedCookieNames.push(name);
+    }
+    return storedCookieNames;
+  }
+
+  getCookieNames(): string[] {
+    return Array.from(this.cookies.keys());
+  }
+
+  getCookieHeader(): string {
+    return Array.from(this.cookies)
+      .map(([name, value]) => `${name}=${value}`)
+      .join("; ");
+  }
+
+  needsXsrfWarmup(request: HttpRequest): boolean {
+    return isUploadMutation(request) && !this.cookies.has(XSRF_COOKIE_NAME);
+  }
+
+  applyToRequest(request: HttpRequest): HttpRequest {
+    const cookieHeader = this.getCookieHeader();
+    const xsrfCookie = this.cookies.get(XSRF_COOKIE_NAME);
+    if (!cookieHeader && !(xsrfCookie && isUploadMutation(request))) {
+      return request;
+    }
+
+    const headers = { ...request.headers };
+    if (cookieHeader) {
+      const existingCookieHeader = getHeader(headers, "cookie");
+      headers.Cookie = existingCookieHeader
+        ? `${existingCookieHeader}; ${cookieHeader}`
+        : cookieHeader;
+    }
+
+    if (
+      xsrfCookie &&
+      isUploadMutation(request) &&
+      !hasHeader(headers, "X-Xsrftoken")
+    ) {
+      headers["X-Xsrftoken"] = xsrfCookie;
+    }
+
+    return {
+      ...request,
+      headers,
+    };
+  }
+}

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -19,6 +19,7 @@ import type {
   WorkerInitialData,
   OutMessage,
   InMessage,
+  InMessageHttpRequest,
   ReplyMessage,
   ModuleAutoLoadMessage,
 } from "./types";
@@ -30,6 +31,7 @@ import {
   type AsgiApp,
   type AsgiEvent,
 } from "./asgi-bridge";
+import { HttpCookieJar } from "./http-cookie";
 
 export type PostMessageFn = (
   message: OutMessage,
@@ -539,6 +541,49 @@ export function startWorkerEnv(
     null;
   let appReadyPromise: Promise<AsgiAppHandle> | null = null;
   let wsSession: AsgiWebSocketSession | null = null;
+  const httpCookieJar = new HttpCookieJar();
+
+  async function warmUpXsrfCookie(
+    asgiApp: AsgiApp,
+    requestPath: string,
+  ): Promise<void> {
+    console.debug("stlite XSRF warmup before upload", { requestPath });
+    const response = await dispatchHttp(
+      asgiApp,
+      httpCookieJar.applyToRequest({
+        method: "GET",
+        path: "/_stcore/health",
+        headers: { host: "stlite.local" },
+        body: "",
+      }),
+    );
+    const storedCookieNames = httpCookieJar.storeFromResponse(response.headers);
+    console.debug("stlite XSRF warmup response", {
+      requestPath,
+      statusCode: response.statusCode,
+      storedCookieNames,
+      cookieNames: httpCookieJar.getCookieNames(),
+    });
+  }
+
+  async function dispatchHttpWithCookies(
+    asgiApp: AsgiApp,
+    request: InMessageHttpRequest["data"]["request"],
+  ) {
+    const decodedRequest = {
+      ...request,
+      path: decodeURIComponent(request.path),
+    };
+
+    if (httpCookieJar.needsXsrfWarmup(decodedRequest)) {
+      await warmUpXsrfCookie(asgiApp, decodedRequest.path);
+    }
+
+    const requestWithCookies = httpCookieJar.applyToRequest(decodedRequest);
+    const response = await dispatchHttp(asgiApp, requestWithCookies);
+    httpCookieJar.storeFromResponse(response.headers);
+    return response;
+  }
 
   /**
    * Process a message sent to the worker.
@@ -645,6 +690,7 @@ export function startWorkerEnv(
             wsSession = null;
           }
           await shutdownApp(pyodide, appHandle);
+          httpCookieJar.clear();
 
           console.debug("Booting up the Streamlit ASGI app");
           appReadyPromise = bootstrapApp(pyodide, appId, entrypoint);
@@ -660,6 +706,7 @@ export function startWorkerEnv(
           console.debug("websocket:connect", msg.data);
 
           const { path } = msg.data;
+          const cookieHeader = httpCookieJar.getCookieHeader();
 
           if (wsSession) {
             // The current kernel only manages one WebSocket per app at a
@@ -676,6 +723,7 @@ export function startWorkerEnv(
             headers: {
               host: "stlite.local",
               origin: "http://stlite.local",
+              ...(cookieHeader ? { cookie: cookieHeader } : {}),
             },
           });
           wsSession = new AsgiWebSocketSession(
@@ -704,11 +752,7 @@ export function startWorkerEnv(
           console.debug("http:request", msg.data);
 
           const { request } = msg.data;
-
-          dispatchHttp(appHandle.asgiApp, {
-            ...request,
-            path: decodeURIComponent(request.path),
-          })
+          dispatchHttpWithCookies(appHandle.asgiApp, request)
             .then((response) => {
               reply({
                 type: "http:response",

--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -557,12 +557,10 @@ export function startWorkerEnv(
         body: "",
       }),
     );
-    const storedCookieNames = httpCookieJar.storeFromResponse(response.headers);
+    httpCookieJar.storeFromResponse(response.headers);
     console.debug("stlite XSRF warmup response", {
       requestPath,
       statusCode: response.statusCode,
-      storedCookieNames,
-      cookieNames: httpCookieJar.getCookieNames(),
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #2068.

- Preserve Streamlit `Set-Cookie` values inside stlite's worker-side ASGI transport.
- Lazily warm up the `_streamlit_xsrf` cookie with `GET /_stcore/health` before the first upload/delete mutation when needed.
- Send the stored cookie and matching `X-Xsrftoken` header for `/_stcore/upload_file` PUT/DELETE requests.
- Add targeted debug logs for XSRF warmup and file upload/delete request status without printing token values.

## Root Cause

`@stlite/browser@1.8.0` moved file uploads through the in-worker ASGI bridge. That path did not keep the XSRF cookie issued by Streamlit's Starlette app, so upload mutations reached `/_stcore/upload_file` without the double-submit cookie/header pair and Streamlit returned 403.

## Validation

- `yarn workspace @stlite/kernel check:lint`
- `yarn workspace @stlite/kernel check:format`
- `yarn workspace @stlite/kernel vitest run src/http-cookie.test.ts`
- `yarn workspace @stlite/kernel build`
- `yarn exec eslint --cache --max-warnings 0 lib/src/FileUploadClient.ts`
- `yarn changeset status --since main`
- Manual confirmation that the reported upload case no longer returns 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file uploads in the browser worker by correctly preserving and propagating Streamlit’s XSRF cookie, and injecting the required XSRF header for upload requests when needed.

* **Tests**
  * Added automated coverage for cookie jar behavior, including merging `Cookie` headers, XSRF header injection rules, and correct “warmup” behavior across request lifecycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->