### PR TITLE
Harden privileged post-build deployments

### DIFF
--- a/.github/actions/verify-artifact-attestation/action.yml
+++ b/.github/actions/verify-artifact-attestation/action.yml
@@ -23,16 +23,17 @@ runs:
           --repo "$GITHUB_REPOSITORY" \
           --predicate-type https://slsa.dev/provenance/v1 \
           --format json)
-        jq -r '.[].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow.path' <<< "$VERIFICATION_RESULT" | \
-          grep -Fx -- "$EXPECTED_WORKFLOW_FILE" || {
-            echo "Error: Attestation does not match expected workflow definition path" >&2
-            exit 1
-          }
-        jq -r '.[].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow.ref' <<< "$VERIFICATION_RESULT" | \
-          grep -Fx -- "$EXPECTED_REF" || {
-            echo "Error: Attestation does not match expected workflow trigger ref" >&2
-            exit 1
-          }
+        # Both fields have to hold on the *same* statement: asserting them separately
+        # lets one attestation supply the path while another supplies the ref.
+        jq -e --arg path "$EXPECTED_WORKFLOW_FILE" --arg ref "$EXPECTED_REF" '
+          any(
+            .[].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow;
+            .path == $path and .ref == $ref
+          )
+        ' <<< "$VERIFICATION_RESULT" > /dev/null || {
+          echo "Error: No attestation matches both the expected workflow definition path and trigger ref" >&2
+          exit 1
+        }
       env:
         FILEPATH: ${{ inputs.filepath }}
         EXPECTED_WORKFLOW_FILE: ${{ inputs.expected-workflow-file }}

--- a/.github/actions/verify-artifact-attestation/action.yml
+++ b/.github/actions/verify-artifact-attestation/action.yml
@@ -19,19 +19,22 @@ runs:
   steps:
     - shell: bash
       run: |
-        VERIFICATION_RESULT=$(gh attestation verify ${{ inputs.filepath }} \
-          --repo ${{ github.repository }} \
+        VERIFICATION_RESULT=$(gh attestation verify "$FILEPATH" \
+          --repo "$GITHUB_REPOSITORY" \
           --predicate-type https://slsa.dev/provenance/v1 \
           --format json)
         jq -r '.[].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow.path' <<< "$VERIFICATION_RESULT" | \
-          grep -Fx '${{ inputs.expected-workflow-file }}' || {
+          grep -Fx -- "$EXPECTED_WORKFLOW_FILE" || {
             echo "Error: Attestation does not match expected workflow definition path" >&2
             exit 1
           }
         jq -r '.[].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow.ref' <<< "$VERIFICATION_RESULT" | \
-          grep -Fx '${{ inputs.expected-ref }}' || {
+          grep -Fx -- "$EXPECTED_REF" || {
             echo "Error: Attestation does not match expected workflow trigger ref" >&2
             exit 1
           }
       env:
+        FILEPATH: ${{ inputs.filepath }}
+        EXPECTED_WORKFLOW_FILE: ${{ inputs.expected-workflow-file }}
+        EXPECTED_REF: ${{ inputs.expected-ref }}
         GH_TOKEN: ${{ inputs.GH_TOKEN }}

--- a/.github/actions/verify-pages-static-output/action.yml
+++ b/.github/actions/verify-pages-static-output/action.yml
@@ -1,0 +1,23 @@
+name: Verify static Pages output
+description: rejects executable Cloudflare Pages output
+inputs:
+  directory:
+    required: true
+    description: Pages output directory
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        DIRECTORY: ${{ inputs.directory }}
+      run: |
+        if [ ! -d "$DIRECTORY" ]; then
+          echo "Error: Pages output directory not found: $DIRECTORY" >&2
+          exit 1
+        fi
+
+        if [ -e "$DIRECTORY/_worker.js" ] || [ -L "$DIRECTORY/_worker.js" ]; then
+          echo "Error: Untrusted Pages output must not contain _worker.js." >&2
+          exit 1
+        fi

--- a/.github/actions/verify-pages-static-output/action.yml
+++ b/.github/actions/verify-pages-static-output/action.yml
@@ -17,7 +17,11 @@ runs:
           exit 1
         fi
 
-        if [ -e "$DIRECTORY/_worker.js" ] || [ -L "$DIRECTORY/_worker.js" ]; then
-          echo "Error: Untrusted Pages output must not contain _worker.js." >&2
-          exit 1
-        fi
+        # Both are entry points for Pages Functions, which would run with the
+        # project's bindings. https://developers.cloudflare.com/pages/functions/
+        for entrypoint in _worker.js functions; do
+          if [ -e "$DIRECTORY/$entrypoint" ] || [ -L "$DIRECTORY/$entrypoint" ]; then
+            echo "Error: Untrusted Pages output must not contain $entrypoint." >&2
+            exit 1
+          fi
+        done

--- a/.github/workflows/postbuild.yml
+++ b/.github/workflows/postbuild.yml
@@ -1039,7 +1039,9 @@ jobs:
         deploy-sharing,
         deploy-sharing-editor,
       ]
-    if: ${{ !cancelled() && needs.get-build-info.outputs.pr-number != '' }}
+    # `always()`, not `!cancelled()`: the pending status is already published by
+    # this point, so a cancelled run still has to resolve it to a terminal state.
+    if: ${{ always() && needs.get-build-info.outputs.pr-number != '' }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -1073,17 +1075,25 @@ jobs:
             const failed = Object.entries(results)
               .filter(([, result]) => result !== "success" && result !== "skipped")
               .map(([name]) => name);
+            const cancelled = Object.values(results).includes("cancelled");
+
+            let state = "success";
+            let description = "Post-build deployments succeeded";
+            if (cancelled) {
+              state = "error";
+              description = "Post-build deployments were cancelled";
+            } else if (failed.length > 0) {
+              state = "failure";
+              description = `Failed: ${failed.join(", ")}`.slice(0, 140);
+            }
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: process.env.HEAD_SHA,
-              state: failed.length === 0 ? "success" : "failure",
+              state,
               context: "post-build",
-              description:
-                failed.length === 0
-                  ? "Post-build deployments succeeded"
-                  : `Failed: ${failed.join(", ")}`.slice(0, 140),
+              description,
               target_url: process.env.TARGET_URL,
             });
 

--- a/.github/workflows/postbuild.yml
+++ b/.github/workflows/postbuild.yml
@@ -23,6 +23,8 @@ jobs:
   get-build-info:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       branch: ${{ steps.build-info.outputs.branch }}
       trigger-sha: ${{ steps.build-info.outputs.trigger-sha }}
@@ -37,6 +39,11 @@ jobs:
           script: |
             const run = context.payload.workflow_run;
             const repository = context.payload.repository;
+
+            if (!/^[0-9a-f]{40}$/.test(run.head_sha)) {
+              core.setFailed(`Malformed workflow run head SHA: ${run.head_sha}`);
+              return;
+            }
 
             if (run.event === "push") {
               if (run.head_branch !== repository.default_branch) {
@@ -57,21 +64,49 @@ jobs:
               return;
             }
 
-            const pullRequests = (run.pull_requests ?? []).filter(
-              (pullRequest) =>
-                pullRequest.base.repo.id === repository.id &&
-                pullRequest.base.ref === repository.default_branch &&
-                pullRequest.head.sha === run.head_sha,
-            );
-            if (pullRequests.length !== 1) {
-              core.setFailed("Could not identify exactly one triggering pull request.");
+            const isTriggeringPullRequest = (pullRequest) =>
+              pullRequest.base.repo.id === repository.id &&
+              pullRequest.base.ref === repository.default_branch &&
+              pullRequest.head.sha === run.head_sha;
+
+            let candidates = (run.pull_requests ?? []).filter(isTriggeringPullRequest);
+            if (candidates.length === 0) {
+              // `workflow_run.pull_requests` is always empty when the run came from a fork,
+              // so ask the API which pull requests the commit belongs to instead.
+              // https://github.com/actions/runner/issues/3444
+              const associated = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: run.head_sha,
+                },
+              );
+              candidates = associated.filter(
+                (pullRequest) =>
+                  pullRequest.state === "open" && isTriggeringPullRequest(pullRequest),
+              );
+            }
+
+            if (candidates.length > 1) {
+              core.setFailed(
+                `Ambiguous triggering pull request: ${candidates.map((pullRequest) => pullRequest.number).join(", ")}`,
+              );
+              return;
+            }
+            if (candidates.length === 0) {
+              // The run has been superseded by a newer head; leave every output empty so
+              // the downstream jobs skip instead of deploying to an unidentified target.
+              core.notice(
+                `No open pull request has ${run.head_sha} as its head; skipping post-build deployments.`,
+              );
               return;
             }
 
-            const pullRequest = pullRequests[0];
+            const pullRequest = candidates[0];
             core.setOutput("branch", `pr-${pullRequest.number}`);
             core.setOutput("trigger-sha", run.head_sha);
-            core.setOutput("head-sha", pullRequest.head.sha);
+            core.setOutput("head-sha", run.head_sha);
             core.setOutput("pr-number", pullRequest.number.toString());
             core.setOutput("attestation-ref", `refs/pull/${pullRequest.number}/merge`);
 
@@ -89,16 +124,10 @@ jobs:
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const sha = process.env.HEAD_SHA;
-            if (!/^[0-9a-f]{40}$/.test(sha)) {
-              core.setFailed("Invalid pull request head SHA.");
-              return;
-            }
-
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha,
+              sha: process.env.HEAD_SHA,
               state: "pending",
               context: "post-build",
               description: "Post-build deployments are running",
@@ -432,6 +461,7 @@ jobs:
 
   e2e-browser-browserstack:
     needs: get-build-info
+    if: ${{ needs.get-build-info.outputs.branch != '' }}
 
     permissions:
       contents: read
@@ -515,7 +545,7 @@ jobs:
 
   deploy-browser-preview:
     needs: [get-build-info, e2e-browser-browserstack]
-    if: ${{ needs.get-build-info.result == 'success' && ( needs.get-build-info.outputs.pr-number != '' || success() ) }}
+    if: ${{ needs.get-build-info.outputs.branch != '' && ( needs.get-build-info.outputs.pr-number != '' || success() ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -659,7 +689,7 @@ jobs:
 
   deploy-react-preview:
     needs: [get-build-info]
-    if: ${{ needs.get-build-info.result == 'success' && ( needs.get-build-info.outputs.pr-number != '' || success() ) }}
+    if: ${{ needs.get-build-info.outputs.branch != '' && ( needs.get-build-info.outputs.pr-number != '' || success() ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -770,7 +800,7 @@ jobs:
 
   deploy-docs-preview:
     needs: [get-build-info]
-    if: ${{ needs.get-build-info.result == 'success' && ( needs.get-build-info.outputs.pr-number != '' || success() ) }}
+    if: ${{ needs.get-build-info.outputs.branch != '' && ( needs.get-build-info.outputs.pr-number != '' || success() ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1009,7 +1039,7 @@ jobs:
         deploy-sharing,
         deploy-sharing-editor,
       ]
-    if: ${{ always() && needs.get-build-info.outputs.pr-number != '' }}
+    if: ${{ !cancelled() && needs.get-build-info.outputs.pr-number != '' }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -1029,33 +1059,31 @@ jobs:
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const sha = process.env.HEAD_SHA;
-            if (!/^[0-9a-f]{40}$/.test(sha)) {
-              core.setFailed("Invalid pull request head SHA.");
-              return;
-            }
-
-            const results = [
-              process.env.PENDING_STATUS_RESULT,
-              process.env.VISUALIZER_RESULT,
-              process.env.E2E_RESULT,
-              process.env.BROWSER_RESULT,
-              process.env.REACT_RESULT,
-              process.env.DOCS_RESULT,
-              process.env.SHARING_RESULT,
-              process.env.SHARING_EDITOR_RESULT,
-            ];
-            const succeeded = results.every((result) => result === "success");
+            const results = {
+              "status-pending": process.env.PENDING_STATUS_RESULT,
+              "visualizer-reports": process.env.VISUALIZER_RESULT,
+              "e2e-browserstack": process.env.E2E_RESULT,
+              "browser-preview": process.env.BROWSER_RESULT,
+              "react-preview": process.env.REACT_RESULT,
+              "docs-preview": process.env.DOCS_RESULT,
+              sharing: process.env.SHARING_RESULT,
+              "sharing-editor": process.env.SHARING_EDITOR_RESULT,
+            };
+            // A gated-off job reports `skipped`, which is not a deployment failure.
+            const failed = Object.entries(results)
+              .filter(([, result]) => result !== "success" && result !== "skipped")
+              .map(([name]) => name);
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha,
-              state: succeeded ? "success" : "failure",
+              sha: process.env.HEAD_SHA,
+              state: failed.length === 0 ? "success" : "failure",
               context: "post-build",
-              description: succeeded
-                ? "Post-build deployments succeeded"
-                : "One or more post-build jobs failed",
+              description:
+                failed.length === 0
+                  ? "Post-build deployments succeeded"
+                  : `Failed: ${failed.join(", ")}`.slice(0, 140),
               target_url: process.env.TARGET_URL,
             });
 

--- a/.github/workflows/postbuild.yml
+++ b/.github/workflows/postbuild.yml
@@ -23,31 +23,87 @@ jobs:
   get-build-info:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     outputs:
       branch: ${{ steps.build-info.outputs.branch }}
       trigger-sha: ${{ steps.build-info.outputs.trigger-sha }}
       head-sha: ${{ steps.build-info.outputs.head-sha }}
       pr-number: ${{ steps.build-info.outputs.pr-number }}
+      attestation-ref: ${{ steps.build-info.outputs.attestation-ref }}
     steps:
-      - name: Download build info
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: build-info
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: Read build info
+      - name: Read trusted build info
         id: build-info
-        run: |
-          echo "branch=$(cat branch)"
-          echo "branch=$(cat branch)" >> $GITHUB_OUTPUT
-          echo "trigger-sha=$(cat trigger-sha)"
-          echo "trigger-sha=$(cat trigger-sha)" >> $GITHUB_OUTPUT
-          echo "head-sha=$(cat head-sha)"
-          echo "head-sha=$(cat head-sha)" >> $GITHUB_OUTPUT
-          echo "pr-number=$(cat pr-number)"
-          echo "pr-number=$(cat pr-number)" >> $GITHUB_OUTPUT
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const repository = context.payload.repository;
+
+            if (run.event === "push") {
+              if (run.head_branch !== repository.default_branch) {
+                core.setFailed("Refusing a push deployment from a non-default branch.");
+                return;
+              }
+
+              core.setOutput("branch", repository.default_branch);
+              core.setOutput("trigger-sha", run.head_sha);
+              core.setOutput("head-sha", run.head_sha);
+              core.setOutput("pr-number", "");
+              core.setOutput("attestation-ref", `refs/heads/${repository.default_branch}`);
+              return;
+            }
+
+            if (run.event !== "pull_request") {
+              core.setFailed(`Unsupported triggering event: ${run.event}`);
+              return;
+            }
+
+            const pullRequests = (run.pull_requests ?? []).filter(
+              (pullRequest) =>
+                pullRequest.base.repo.id === repository.id &&
+                pullRequest.base.ref === repository.default_branch &&
+                pullRequest.head.sha === run.head_sha,
+            );
+            if (pullRequests.length !== 1) {
+              core.setFailed("Could not identify exactly one triggering pull request.");
+              return;
+            }
+
+            const pullRequest = pullRequests[0];
+            core.setOutput("branch", `pr-${pullRequest.number}`);
+            core.setOutput("trigger-sha", run.head_sha);
+            core.setOutput("head-sha", pullRequest.head.sha);
+            core.setOutput("pr-number", pullRequest.number.toString());
+            core.setOutput("attestation-ref", `refs/pull/${pullRequest.number}/merge`);
+
+  set-post-build-status-pending:
+    needs: get-build-info
+    if: ${{ needs.get-build-info.outputs.pr-number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set pending commit status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ needs.get-build-info.outputs.head-sha }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const sha = process.env.HEAD_SHA;
+            if (!/^[0-9a-f]{40}$/.test(sha)) {
+              core.setFailed("Invalid pull request head SHA.");
+              return;
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: "pending",
+              context: "post-build",
+              description: "Post-build deployments are running",
+              target_url: process.env.TARGET_URL,
+            });
 
   get-changesets-publish-targets:
     if: github.event.workflow_run.conclusion == 'success'
@@ -116,6 +172,12 @@ jobs:
       has-reports: ${{ steps.check-artifacts.outputs.has-reports }}
       report-links: ${{ steps.generate-links.outputs.links }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
+
       - name: Check for visualizer artifacts
         id: check-artifacts
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -281,6 +343,12 @@ jobs:
           echo -e "$links" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Verify static Pages output
+        if: steps.check-artifacts.outputs.has-reports
+        uses: ./.github/actions/verify-pages-static-output
+        with:
+          directory: ${{ runner.temp }}/visualizer-reports
+
       - name: Deploy to Cloudflare Pages
         if: steps.check-artifacts.outputs.has-reports
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
@@ -288,6 +356,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ${{ runner.temp }}
           command: |
             pages deploy ${{ runner.temp }}/visualizer-reports --project-name=stlite-bundle-visualizer-reports --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.trigger-sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -481,11 +550,16 @@ jobs:
         with:
           filepath: ${{ runner.temp }}/artifacts/browser/package.tgz
           expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: ${{ needs.get-build-info.outputs.pr-number && format('refs/pull/{0}/merge', needs.get-build-info.outputs.pr-number) || format('refs/heads/{0}', needs.get-build-info.outputs.branch) }}
+          expected-ref: ${{ needs.get-build-info.outputs.attestation-ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: tar xzvf package.tgz
         working-directory: ${{ runner.temp }}/artifacts/browser
+
+      - name: Verify static Pages output
+        uses: ./.github/actions/verify-pages-static-output
+        with:
+          directory: ${{ runner.temp }}/artifacts/browser/package/build
 
       - name: Deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
@@ -493,6 +567,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ${{ runner.temp }}
           command: |
             pages deploy ${{ runner.temp }}/artifacts/browser/package/build --project-name=stlite-browser-preview --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.trigger-sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -618,11 +693,16 @@ jobs:
         with:
           filepath: ${{ runner.temp }}/artifacts/react/package.tgz
           expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: ${{ needs.get-build-info.outputs.pr-number && format('refs/pull/{0}/merge', needs.get-build-info.outputs.pr-number) || format('refs/heads/{0}', needs.get-build-info.outputs.branch) }}
+          expected-ref: ${{ needs.get-build-info.outputs.attestation-ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: tar xzvf package.tgz
         working-directory: ${{ runner.temp }}/artifacts/react
+
+      - name: Verify static Pages output
+        uses: ./.github/actions/verify-pages-static-output
+        with:
+          directory: ${{ runner.temp }}/artifacts/react/package/build
 
       - name: Deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
@@ -630,6 +710,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ${{ runner.temp }}
           command: |
             pages deploy ${{ runner.temp }}/artifacts/react/package/build --project-name=stlite-react-preview --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.trigger-sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -717,8 +798,13 @@ jobs:
         with:
           filepath: "${{ runner.temp }}/artifacts/docs/index.html" # XXX: Only index.html is verified because the verification command only supports a single file input, while it may be better to verify all files, which takes a longer time though.
           expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: ${{ needs.get-build-info.outputs.pr-number && format('refs/pull/{0}/merge', needs.get-build-info.outputs.pr-number) || format('refs/heads/{0}', needs.get-build-info.outputs.branch) }}
+          expected-ref: ${{ needs.get-build-info.outputs.attestation-ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify static Pages output
+        uses: ./.github/actions/verify-pages-static-output
+        with:
+          directory: ${{ runner.temp }}/artifacts/docs
 
       - name: Deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
@@ -726,6 +812,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ${{ runner.temp }}
           command: |
             pages deploy ${{ runner.temp }}/artifacts/docs --project-name=stlite-docs --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.trigger-sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -787,6 +874,12 @@ jobs:
     outputs:
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
+
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -795,12 +888,18 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify static Pages output
+        uses: ./.github/actions/verify-pages-static-output
+        with:
+          directory: ${{ runner.temp }}/artifacts/sharing
+
       - name: Deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         id: deploy
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ${{ runner.temp }}
           command: |
             pages deploy ${{ runner.temp }}/artifacts/sharing --project-name=stlite-sharing --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.trigger-sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -816,6 +915,12 @@ jobs:
     outputs:
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
+
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -828,12 +933,18 @@ jobs:
         run: |
           echo '${{ needs.deploy-sharing.outputs.url }}' > ${{ runner.temp }}/artifacts/sharing-editor/SHARING_APP_URL
 
+      - name: Verify static Pages output
+        uses: ./.github/actions/verify-pages-static-output
+        with:
+          directory: ${{ runner.temp }}/artifacts/sharing-editor
+
       - name: Deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         id: deploy
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ${{ runner.temp }}
           command: pages deploy ${{ runner.temp }}/artifacts/sharing-editor --project-name=stlite-sharing-editor --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.trigger-sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
@@ -884,6 +995,69 @@ jobs:
           order: "45"
           section-content: |
             ⚠️ Deployment failed. Check the [workflow logs](${{ env.LOG_URL }}) for details.
+
+  set-post-build-status-final:
+    needs:
+      [
+        get-build-info,
+        set-post-build-status-pending,
+        deploy-visualizer-reports,
+        e2e-browser-browserstack,
+        deploy-browser-preview,
+        deploy-react-preview,
+        deploy-docs-preview,
+        deploy-sharing,
+        deploy-sharing-editor,
+      ]
+    if: ${{ always() && needs.get-build-info.outputs.pr-number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set final commit status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ needs.get-build-info.outputs.head-sha }}
+          PENDING_STATUS_RESULT: ${{ needs.set-post-build-status-pending.result }}
+          VISUALIZER_RESULT: ${{ needs.deploy-visualizer-reports.result }}
+          E2E_RESULT: ${{ needs.e2e-browser-browserstack.result }}
+          BROWSER_RESULT: ${{ needs.deploy-browser-preview.result }}
+          REACT_RESULT: ${{ needs.deploy-react-preview.result }}
+          DOCS_RESULT: ${{ needs.deploy-docs-preview.result }}
+          SHARING_RESULT: ${{ needs.deploy-sharing.result }}
+          SHARING_EDITOR_RESULT: ${{ needs.deploy-sharing-editor.result }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const sha = process.env.HEAD_SHA;
+            if (!/^[0-9a-f]{40}$/.test(sha)) {
+              core.setFailed("Invalid pull request head SHA.");
+              return;
+            }
+
+            const results = [
+              process.env.PENDING_STATUS_RESULT,
+              process.env.VISUALIZER_RESULT,
+              process.env.E2E_RESULT,
+              process.env.BROWSER_RESULT,
+              process.env.REACT_RESULT,
+              process.env.DOCS_RESULT,
+              process.env.SHARING_RESULT,
+              process.env.SHARING_EDITOR_RESULT,
+            ];
+            const succeeded = results.every((result) => result === "success");
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: succeeded ? "success" : "failure",
+              context: "post-build",
+              description: succeeded
+                ? "Post-build deployments succeeded"
+                : "One or more post-build jobs failed",
+              target_url: process.env.TARGET_URL,
+            });
 
   publish-browser:
     needs: [get-build-info, get-changesets-publish-targets]


### PR DESCRIPTION
## Summary

- derive deployment routing from validated `workflow_run` metadata instead of PR-controlled artifacts
- namespace pull-request Pages branches as `pr-<number>`
- prevent shell injection in artifact-attestation checks
- reject executable `_worker.js` files from untrusted Pages outputs and run Wrangler from an isolated directory
- publish an aggregate `post-build` status on the triggering pull-request SHA

## Why

The privileged post-build workflow consumes artifacts produced by pull-request workflows while holding Cloudflare credentials and write-capable GitHub tokens. PR-controlled metadata could select production Pages deployments, attestation inputs were interpolated into Bash, and uploaded Pages directories could add executable Functions that inherit project bindings. Deployment failures also were not represented by a single status on the pull-request commit.

## Impact

Fork previews remain supported, but their Pages branch names now come from trusted PR numbers and their outputs must remain static. A new `post-build` commit status covers all required preview deployments; repository rules should require that context before merging.

The legacy `build-info` artifact is intentionally retained in `test-build.yml` during rollout because `workflow_run` uses the post-build definition from the default branch. The hardened workflow no longer consumes it after this change lands.

## Validation

- `actionlint -ignore 'shellcheck reported issue' .github/workflows/postbuild.yml`
- Prettier check for all changed YAML files
- YAML parsing with Ruby Psych
- `git diff --check`
- local policy test confirming static output is accepted and `_worker.js` is rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Pages static-output verification step to block deploying executable Cloudflare Pages output.
  * Added consolidated post-build status reporting that aggregates preview, deployment, and end-to-end results into a single final status.

* **Bug Fixes**
  * Improved artifact attestation verification for more reliable validation against expected workflow and trigger context.
  * Improved deployment workflow handling by deriving build/PR targeting directly from the triggering event, with stricter gating and clearer failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->