### PR TITLE
Drop the unused build-info artifact

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,41 +22,34 @@ jobs:
   set-build-info:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.build-info.outputs.branch }}
-      trigger-sha: ${{ steps.build-info.outputs.trigger-sha }}
-      head-sha: ${{ steps.build-info.outputs.head-sha }}
-      pr-number: ${{ steps.build-info.outputs.pr-number }}
+      branch: ${{ steps.pull-request.outputs.branch || steps.push.outputs.branch }}
+      head-sha: ${{ steps.pull-request.outputs.head-sha || steps.push.outputs.head-sha }}
+      pr-number: ${{ steps.pull-request.outputs.pr-number }}
     steps:
       - name: Save build info (pull_request)
         if: github.event_name == 'pull_request'
+        id: pull-request
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "${{ github.event.pull_request.head.ref }}" > branch
-          echo "${{ github.event.pull_request.head.sha }}" > head-sha
-          echo "${{ github.sha }}" > trigger-sha
-          echo "${{ github.event.pull_request.number }}" > pr-number
+          {
+            echo "branch=$BRANCH"
+            echo "head-sha=$HEAD_SHA"
+            echo "pr-number=$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
       - name: Save build info (push, branch)
         if: github.event_name == 'push' && github.ref_type == 'branch'
+        id: push
+        env:
+          BRANCH: ${{ github.ref_name }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          echo "${{ github.ref_name }}" > branch
-          echo "${{ github.sha }}" > head-sha
-          echo "${{ github.sha }}" > trigger-sha
-          echo "" > pr-number
-      - name: Output build info
-        id: build-info
-        run: |
-          echo "branch=$(cat branch)" >> $GITHUB_OUTPUT
-          echo "trigger-sha=$(cat trigger-sha)" >> $GITHUB_OUTPUT
-          echo "head-sha=$(cat head-sha)" >> $GITHUB_OUTPUT
-          echo "pr-number=$(cat pr-number)" >> $GITHUB_OUTPUT
-      - name: Upload build info
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: build-info
-          path: |
-            branch
-            head-sha
-            trigger-sha
-            pr-number
+          {
+            echo "branch=$BRANCH"
+            echo "head-sha=$HEAD_SHA"
+          } >> "$GITHUB_OUTPUT"
 
   changesets:
     if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}


### PR DESCRIPTION
Nothing downloads `build-info` since #2081 made the post-build workflow derive its deployment target from the `workflow_run` payload, and `trigger-sha` has no consumers left at all.

Without the upload the job no longer needs to stage values in files, so it writes `$GITHUB_OUTPUT` directly. That also moves `github.event.pull_request.head.ref` out of `run:` and into `env:`.

`branch`, `head-sha` and `pr-number` are still consumed within this workflow and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build metadata handling for automated builds.
  * Build records now include branch, commit, and pull request information where applicable.
  * Removed the previous build information artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->