### PR TITLE
fix(cli): avoid forced major bumps by dropping target `peerDependencies`

### DIFF
--- a/.changeset/cli-optional-runtime-deps.md
+++ b/.changeset/cli-optional-runtime-deps.md
@@ -2,4 +2,4 @@
 "@stlite/cli": patch
 ---
 
-Load each target's runtime package (`@stlite/browser`, `@stlite/desktop`, `@stlite/cloudflare`) lazily and declare them as optional peer dependencies, so an install that omits a target still works for the others and the heavy per-target artifacts are not pulled in unless requested. Each command reports a clear "install …" message when its target's package is missing, and verifies the installed version satisfies the range this CLI supports — failing loudly and actionably instead of silently mishandling a drifted plugin interface.
+Load each target's runtime package (`@stlite/browser`, `@stlite/desktop`, `@stlite/cloudflare`) lazily instead of depending on them at runtime, so an install that omits a target still works for the others and the heavy per-target artifacts are not pulled in unless requested. Each command reports a clear "install …" message when its target's package is missing, and verifies the installed version satisfies the range this CLI supports — failing loudly and actionably instead of silently mishandling a drifted plugin interface.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,22 +48,6 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.3"
   },
-  "peerDependencies": {
-    "@stlite/browser": "workspace:^",
-    "@stlite/cloudflare": "workspace:^",
-    "@stlite/desktop": "workspace:^"
-  },
-  "peerDependenciesMeta": {
-    "@stlite/browser": {
-      "optional": true
-    },
-    "@stlite/cloudflare": {
-      "optional": true
-    },
-    "@stlite/desktop": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": ">=22"
   }

--- a/packages/cli/src/commands/cloudflare.ts
+++ b/packages/cli/src/commands/cloudflare.ts
@@ -72,11 +72,12 @@ export const cloudflareCommand: CommandModule<unknown, CloudflareArgs> = {
         describe:
           "Worker name for a generated wrangler.jsonc (default: derived from <path>)",
       }),
-  // build() lives in @stlite/cloudflare — an optional dependency, since it ships
-  // heavy Worker runtime artifacts most `stlite` users don't need. Import it
-  // lazily so the CLI works without it, and point the user at the install when
-  // it's missing. build() owns the input validation; this handler just maps the
-  // CLI args onto it and applies the `stlite cloudflare:` error prefix.
+  // build() lives in @stlite/cloudflare, which ships heavy Worker runtime
+  // artifacts most `stlite` users don't need, so the CLI doesn't depend on it at
+  // runtime — install it separately for this command. Import it lazily so the
+  // CLI works without it, and point the user at the install when it's missing.
+  // build() owns the input validation; this handler just maps the CLI args onto
+  // it and applies the `stlite cloudflare:` error prefix.
   handler: async (argv) => {
     // Verify the optional target is installed AND version-compatible before
     // importing it. resolveTargetPackage only resolves (it doesn't load the

--- a/packages/cli/src/package-command.test.ts
+++ b/packages/cli/src/package-command.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { targetVersionSatisfies } from "./package-command.js";
 
@@ -24,5 +27,35 @@ describe("targetVersionSatisfies", () => {
 
   it("considers prereleases of an in-range version compatible", () => {
     expect(targetVersionSatisfies("^0.1.0", "0.1.5-next.1")).toBe(true);
+  });
+});
+
+describe("target dependency declarations in package.json", () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      path.join(
+        fileURLToPath(new URL(".", import.meta.url)),
+        "..",
+        "package.json",
+      ),
+      "utf8",
+    ),
+  );
+  const targets = ["@stlite/browser", "@stlite/desktop", "@stlite/cloudflare"];
+
+  it("keeps runtime targets in devDependencies (the drift-check range source)", () => {
+    // resolveTargetPackage reads each target's supported range from
+    // devDependencies; dropping one from there would silently disable its check.
+    for (const t of targets) {
+      expect(manifest.devDependencies?.[t]).toBeDefined();
+    }
+  });
+
+  it("does not declare runtime targets as peer dependencies", () => {
+    // A peer dependency would make changesets force a major bump of the CLI on
+    // every target release.
+    for (const t of targets) {
+      expect(manifest.peerDependencies?.[t]).toBeUndefined();
+    }
   });
 });

--- a/packages/cli/src/package-command.ts
+++ b/packages/cli/src/package-command.ts
@@ -181,8 +181,7 @@ function findPackageJson(
 function readOwnManifest(): {
   name?: string;
   version?: string;
-  peerDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 } {
   return findPackageJson(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -232,9 +231,15 @@ export function resolveTargetPackage(packageName: string): {
   const version = manifest.version ?? "0.0.0";
 
   const own = readOwnManifest();
-  const range =
-    own.peerDependencies?.[packageName] ??
-    own.optionalDependencies?.[packageName];
+  // The supported range for each target is recorded in this CLI's
+  // devDependencies (rather than dependencies or peerDependencies) so that
+  // installing the CLI doesn't pull the heavy target artifacts, and a target's
+  // own release doesn't force a version bump of the CLI: changesets majors a
+  // package whose peerDependency moves. yarn still rewrites the `workspace:^`
+  // protocol to a real range (e.g. `^0.2.0`) at publish, so the check has teeth
+  // for installed users; inside the monorepo it stays `workspace:^`, which
+  // targetVersionSatisfies treats as always compatible.
+  const range = own.devDependencies?.[packageName];
   if (range != null && !targetVersionSatisfies(range, version)) {
     throw new Error(
       `${packageName}@${version} is not compatible with ${own.name}@${own.version}, which requires ${packageName}@${range}. ` +

--- a/yarn.lock
+++ b/yarn.lock
@@ -7912,17 +7912,6 @@ __metadata:
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.3"
     yargs: "npm:^18.0.0"
-  peerDependencies:
-    "@stlite/browser": "workspace:^"
-    "@stlite/cloudflare": "workspace:^"
-    "@stlite/desktop": "workspace:^"
-  peerDependenciesMeta:
-    "@stlite/browser":
-      optional: true
-    "@stlite/cloudflare":
-      optional: true
-    "@stlite/desktop":
-      optional: true
   bin:
     stlite: ./dist/cli.js
   languageName: unknown


### PR DESCRIPTION
`@stlite/cli` declared `@stlite/browser`, `@stlite/desktop`, and `@stlite/cloudflare` as optional `peerDependencies`. Changesets majors a package whenever one of its peer dependencies is version-bumped, so every target release forced a new CLI major: the pending release PR already jumped `@stlite/cli` to 1.0.0 for a patch-only change.

Drop the `peerDependencies`. The targets stay in `devDependencies` (workspace-linked for dev, not installed by consumers, so the heavy artifacts still aren't auto-pulled), and the version-drift check reads each target's supported range from there. Yarn rewrites the `workspace:^` range to a real one at publish, so the check keeps its teeth for installed users.

`yarn vitest run src/package-command.test.ts` in `packages/cli` covers the range check and asserts the targets stay in `devDependencies` and out of `peerDependencies`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI package configuration for runtime targets.
  * Maintained lazy loading, missing-package installation guidance, and installed-version compatibility checks.
  * Clarified Cloudflare command error handling without changing runtime behavior.

* **Tests**
  * Added coverage to verify runtime targets are declared correctly in the package manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->