### PR TITLE
ci: de-duplicate the `publish-*` jobs and assert tarball metadata before publish

### DIFF
--- a/.github/actions/publish-stlite-package/action.yml
+++ b/.github/actions/publish-stlite-package/action.yml
@@ -1,0 +1,93 @@
+name: Publish an @stlite package to npm
+description: >
+  Download the package tarball that test-build.yml built and attested, verify
+  its contents, provenance, name, and version, publish it to npm via trusted
+  publishing, and create a GitHub release. The calling job must run with
+  `id-token: write` (trusted publishing), `contents: write` (release), and
+  `attestations: read` (attestation verification), and must check out the repo
+  first (this action uses sibling local actions under `.github/actions/`).
+
+inputs:
+  package:
+    description: 'Scope-relative package name, e.g. "cli" for @stlite/cli.'
+    required: true
+  version:
+    description: 'The version being released, e.g. "0.1.3". Must match the tarball.'
+    required: true
+  workflow-run-id:
+    description: The test-build workflow_run id that produced the artifact.
+    required: true
+  github-token:
+    description: Token for the cross-run artifact download and attestation check.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 22
+        registry-url: "https://registry.npmjs.org"
+        scope: "@stlite"
+
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: stlite-${{ inputs.package }}
+        path: ${{ runner.temp }}/stlite-${{ inputs.package }}
+        run-id: ${{ inputs.workflow-run-id }}
+        github-token: ${{ inputs.github-token }}
+
+    - name: Verify artifact contents
+      uses: ./.github/actions/verify-only-file
+      with:
+        directory: ${{ runner.temp }}/stlite-${{ inputs.package }}
+        filename: package.tgz
+
+    - name: Verify artifact attestation
+      uses: ./.github/actions/verify-artifact-attestation
+      with:
+        filepath: ${{ runner.temp }}/stlite-${{ inputs.package }}/package.tgz
+        expected-workflow-file: .github/workflows/test-build.yml
+        expected-ref: refs/heads/main
+        GH_TOKEN: ${{ inputs.github-token }}
+
+    # Ensure npm 11.5.1 or later is installed for trusted publishing.
+    - name: Update npm
+      # Incremental upgrade of npm through 11.10.0 is needed
+      # to avoid the error occurring when directly installing a later version of npm,
+      # as reported in https://github.com/npm/cli/issues/9151
+      shell: bash
+      run: |
+        npm install -g npm@~11.10.0
+        npm install -g npm@latest
+
+    # The attestation proves the tarball's provenance but not that it holds the
+    # version being released. Fail before the irreversible publish if the name or
+    # version in the tarball doesn't match, rather than publishing inconsistent
+    # metadata or tagging a release that doesn't match what shipped.
+    - name: Assert the tarball matches the release
+      shell: bash
+      env:
+        TARBALL: ${{ runner.temp }}/stlite-${{ inputs.package }}/package.tgz
+        EXPECTED_NAME: "@stlite/${{ inputs.package }}"
+        EXPECTED_VERSION: ${{ inputs.version }}
+      run: |
+        MANIFEST=$(tar -xzOf "$TARBALL" package/package.json)
+        NAME=$(printf '%s' "$MANIFEST" | jq -r .name)
+        VERSION=$(printf '%s' "$MANIFEST" | jq -r .version)
+        if [ "$NAME" != "$EXPECTED_NAME" ] || [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+          echo "::error::Refusing to publish: tarball is $NAME@$VERSION but the release is $EXPECTED_NAME@$EXPECTED_VERSION"
+          exit 1
+        fi
+        echo "Verified tarball $NAME@$VERSION"
+
+    - name: Publish validated package
+      shell: bash
+      run: npm publish "${{ runner.temp }}/stlite-${{ inputs.package }}/package.tgz" --access public
+
+    - name: Create a new release
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+      with:
+        files: ${{ runner.temp }}/stlite-${{ inputs.package }}/package.tgz
+        generate_release_notes: true
+        tag_name: "@stlite/${{ inputs.package }}@${{ inputs.version }}"

--- a/.github/workflows/postbuild.yml
+++ b/.github/workflows/postbuild.yml
@@ -1318,6 +1318,7 @@ jobs:
       contents: write # Necessary for creating releases: https://github.com/softprops/action-gh-release#permissions
       id-token: write # Necessary for NPM trusted publishing: https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       attestations: read # Necessary for verifying artifact attestations
+      actions: read # Necessary for downloading the build artifact from the triggering workflow_run
 
     runs-on: ubuntu-latest
 
@@ -1344,6 +1345,7 @@ jobs:
       contents: write # Necessary for creating releases: https://github.com/softprops/action-gh-release#permissions
       id-token: write # Necessary for NPM trusted publishing: https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       attestations: read # Necessary for verifying artifact attestations
+      actions: read # Necessary for downloading the build artifact from the triggering workflow_run
 
     runs-on: ubuntu-latest
 
@@ -1370,6 +1372,7 @@ jobs:
       contents: write # Necessary for creating releases: https://github.com/softprops/action-gh-release#permissions
       id-token: write # Necessary for NPM trusted publishing: https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       attestations: read # Necessary for verifying artifact attestations
+      actions: read # Necessary for downloading the build artifact from the triggering workflow_run
 
     runs-on: ubuntu-latest
 
@@ -1396,6 +1399,7 @@ jobs:
       contents: write # Necessary for creating releases: https://github.com/softprops/action-gh-release#permissions
       id-token: write # Necessary for NPM trusted publishing: https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       attestations: read # Necessary for verifying artifact attestations
+      actions: read # Necessary for downloading the build artifact from the triggering workflow_run
 
     runs-on: ubuntu-latest
 
@@ -1422,6 +1426,7 @@ jobs:
       contents: write # Necessary for creating releases: https://github.com/softprops/action-gh-release#permissions
       id-token: write # Necessary for NPM trusted publishing: https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       attestations: read # Necessary for verifying artifact attestations
+      actions: read # Necessary for downloading the build artifact from the triggering workflow_run
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/postbuild.yml
+++ b/.github/workflows/postbuild.yml
@@ -1322,58 +1322,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout for local actions (`uses ./*`).
+      # Checkout for the local composite actions (`uses: ./*`).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/publish-stlite-package
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@stlite"
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stlite-browser
-          path: ${{ runner.temp }}/stlite-browser
-          run-id: ${{ github.event.workflow_run.id }}
+          package: browser
+          version: ${{ needs.get-changesets-publish-targets.outputs.browser }}
+          workflow-run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify artifact contents
-        uses: ./.github/actions/verify-only-file
-        with:
-          directory: ${{ runner.temp }}/stlite-browser
-          filename: package.tgz
-
-      - name: Verify artifact attestation
-        uses: ./.github/actions/verify-artifact-attestation
-        with:
-          filepath: ${{ runner.temp }}/stlite-browser/package.tgz
-          expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: refs/heads/main
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Ensure npm 11.5.1 or later is installed for trusted publishing
-      - name: Update npm
-        # Incremental upgrade of npm through 11.10.0 is needed
-        # to avoid the error occurring when directly installing a later version of npm,
-        # as reported in https://github.com/npm/cli/issues/9151
-        run: |
-          npm install -g npm@~11.10.0
-          npm install -g npm@latest
-
-      - name: Publish validated package
-        run: npm publish ${{ runner.temp }}/stlite-browser/package.tgz --access public
-
-      - name: Create a new release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ${{ runner.temp }}/stlite-browser/package.tgz
-          generate_release_notes: true
-          tag_name: "@stlite/browser@${{ needs.get-changesets-publish-targets.outputs.browser }}"
 
   publish-react:
     needs: [get-build-info, get-changesets-publish-targets]
@@ -1387,58 +1348,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout for local actions (`uses ./*`).
+      # Checkout for the local composite actions (`uses: ./*`).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/publish-stlite-package
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@stlite"
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stlite-react
-          path: ${{ runner.temp }}/stlite-react
-          run-id: ${{ github.event.workflow_run.id }}
+          package: react
+          version: ${{ needs.get-changesets-publish-targets.outputs.react }}
+          workflow-run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify artifact contents
-        uses: ./.github/actions/verify-only-file
-        with:
-          directory: ${{ runner.temp }}/stlite-react
-          filename: package.tgz
-
-      - name: Verify artifact attestation
-        uses: ./.github/actions/verify-artifact-attestation
-        with:
-          filepath: ${{ runner.temp }}/stlite-react/package.tgz
-          expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: refs/heads/main
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Ensure npm 11.5.1 or later is installed for trusted publishing
-      - name: Update npm
-        # Incremental upgrade of npm through 11.10.0 is needed
-        # to avoid the error occurring when directly installing a later version of npm,
-        # as reported in https://github.com/npm/cli/issues/9151
-        run: |
-          npm install -g npm@~11.10.0
-          npm install -g npm@latest
-
-      - name: Publish validated package
-        run: npm publish ${{ runner.temp }}/stlite-react/package.tgz --access public
-
-      - name: Create a new release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ${{ runner.temp }}/stlite-react/package.tgz
-          generate_release_notes: true
-          tag_name: "@stlite/react@${{ needs.get-changesets-publish-targets.outputs.react }}"
 
   publish-desktop:
     needs: [get-build-info, get-changesets-publish-targets]
@@ -1452,58 +1374,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout for local actions (`uses ./*`).
+      # Checkout for the local composite actions (`uses: ./*`).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/publish-stlite-package
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@stlite"
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stlite-desktop
-          path: ${{ runner.temp }}/stlite-desktop
-          run-id: ${{ github.event.workflow_run.id }}
+          package: desktop
+          version: ${{ needs.get-changesets-publish-targets.outputs.desktop }}
+          workflow-run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify artifact contents
-        uses: ./.github/actions/verify-only-file
-        with:
-          directory: ${{ runner.temp }}/stlite-desktop
-          filename: package.tgz
-
-      - name: Verify artifact attestation
-        uses: ./.github/actions/verify-artifact-attestation
-        with:
-          filepath: ${{ runner.temp }}/stlite-desktop/package.tgz
-          expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: refs/heads/main
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Ensure npm 11.5.1 or later is installed for trusted publishing
-      - name: Update npm
-        # Incremental upgrade of npm through 11.10.0 is needed
-        # to avoid the error occurring when directly installing a later version of npm,
-        # as reported in https://github.com/npm/cli/issues/9151
-        run: |
-          npm install -g npm@~11.10.0
-          npm install -g npm@latest
-
-      - name: Publish validated package
-        run: npm publish ${{ runner.temp }}/stlite-desktop/package.tgz --access public
-
-      - name: Create a new release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ${{ runner.temp }}/stlite-desktop/package.tgz
-          generate_release_notes: true
-          tag_name: "@stlite/desktop@${{ needs.get-changesets-publish-targets.outputs.desktop }}"
 
   publish-cloudflare:
     needs: [get-build-info, get-changesets-publish-targets]
@@ -1517,58 +1400,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout for local actions (`uses ./*`).
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Checkout for the local composite actions (`uses: ./*`).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/publish-stlite-package
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@stlite"
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stlite-cloudflare
-          path: ${{ runner.temp }}/stlite-cloudflare
-          run-id: ${{ github.event.workflow_run.id }}
+          package: cloudflare
+          version: ${{ needs.get-changesets-publish-targets.outputs.cloudflare }}
+          workflow-run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify artifact contents
-        uses: ./.github/actions/verify-only-file
-        with:
-          directory: ${{ runner.temp }}/stlite-cloudflare
-          filename: package.tgz
-
-      - name: Verify artifact attestation
-        uses: ./.github/actions/verify-artifact-attestation
-        with:
-          filepath: ${{ runner.temp }}/stlite-cloudflare/package.tgz
-          expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: refs/heads/main
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Ensure npm 11.5.1 or later is installed for trusted publishing
-      - name: Update npm
-        # Incremental upgrade of npm through 11.10.0 is needed
-        # to avoid the error occurring when directly installing a later version of npm,
-        # as reported in https://github.com/npm/cli/issues/9151
-        run: |
-          npm install -g npm@~11.10.0
-          npm install -g npm@latest
-
-      - name: Publish validated package
-        run: npm publish ${{ runner.temp }}/stlite-cloudflare/package.tgz --access public
-
-      - name: Create a new release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ${{ runner.temp }}/stlite-cloudflare/package.tgz
-          generate_release_notes: true
-          tag_name: "@stlite/cloudflare@${{ needs.get-changesets-publish-targets.outputs.cloudflare }}"
 
   publish-cli:
     needs: [get-build-info, get-changesets-publish-targets]
@@ -1582,55 +1426,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout for local actions (`uses ./*`).
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Checkout for the local composite actions (`uses: ./*`).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/publish-stlite-package
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@stlite"
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stlite-cli
-          path: ${{ runner.temp }}/stlite-cli
-          run-id: ${{ github.event.workflow_run.id }}
+          package: cli
+          version: ${{ needs.get-changesets-publish-targets.outputs.cli }}
+          workflow-run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify artifact contents
-        uses: ./.github/actions/verify-only-file
-        with:
-          directory: ${{ runner.temp }}/stlite-cli
-          filename: package.tgz
-
-      - name: Verify artifact attestation
-        uses: ./.github/actions/verify-artifact-attestation
-        with:
-          filepath: ${{ runner.temp }}/stlite-cli/package.tgz
-          expected-workflow-file: .github/workflows/test-build.yml
-          expected-ref: refs/heads/main
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Ensure npm 11.5.1 or later is installed for trusted publishing
-      - name: Update npm
-        # Incremental upgrade of npm through 11.10.0 is needed
-        # to avoid the error occurring when directly installing a later version of npm,
-        # as reported in https://github.com/npm/cli/issues/9151
-        run: |
-          npm install -g npm@~11.10.0
-          npm install -g npm@latest
-
-      - name: Publish validated package
-        run: npm publish ${{ runner.temp }}/stlite-cli/package.tgz --access public
-
-      - name: Create a new release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ${{ runner.temp }}/stlite-cli/package.tgz
-          generate_release_notes: true
-          tag_name: "@stlite/cli@${{ needs.get-changesets-publish-targets.outputs.cli }}"


### PR DESCRIPTION
Closes #2087.

The five `publish-*` jobs in `postbuild.yml` were near-identical copies of the same download → verify → publish → release sequence, and none checked that the tarball actually matched the release being cut.

Factor that sequence into a `.github/actions/publish-stlite-package` composite action parameterized by package and version, so each job is now a checkout plus one `uses:`. The composite adds a pre-publish assertion that the tarball's `name`/`version` equal `@stlite/<package>@<version>`, failing before the irreversible `npm publish` on a mismatch. Gating in `get-changesets-publish-targets` is unchanged.

It stays a composite action rather than a reusable workflow so the OIDC `job_workflow_ref` remains `postbuild.yml` and the configured npm trusted publishers keep matching. Also unifies the `checkout` pin that had drifted between the jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Standardized publishing for browser, React, desktop, Cloudflare, and CLI packages.
  * Added consistent validation and verification before packages are published.
  * Automated public releases with generated release notes, improving reliability and consistency across package updates.
  * Consolidated publishing workflows to reduce variation and help ensure each package is released through the same trusted process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->