### PR TITLE
docs: remove the sponsors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,11 +644,7 @@ Image processing with OpenCV works on the client side.
 
 ### Streamlit (Snowflake)
 
-[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img src="https://docs.snowflake.com/_images/logo-snowflake-sans-text.png" height="100" />](https://www.snowflake.com/)
-
-### TestMu AI
-
-[<picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.testmuai.com/resources/images/logos/white-logo.png"><source media="(prefers-color-scheme: light)" srcset="https://assets.testmuai.com/resources/images/logos/black-logo.png"><img alt="TestMu AI logo" src="https://assets.testmuai.com/resources/images/logos/white-logo.png" height="85"></picture>](https://www.testmuai.com/?utm_medium=sponsor&utm_source=stlite)
+[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
 
 ### Hal9
 

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ Image processing with OpenCV works on the client side.
 
 ### Streamlit (Snowflake)
 
-[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
+[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img alt="Snowflake" src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
 
 ### Hal9
 

--- a/README.md
+++ b/README.md
@@ -640,24 +640,6 @@ Image processing with OpenCV works on the client side.
 
 </details>
 
-## Sponsors
-
-### Streamlit (Snowflake)
-
-[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img alt="Snowflake" src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
-
-### Hal9
-
-[<img src="https://hal9.com/logo/hal9-square-black.png" height="50" >](https://hal9.com/)
-
-They are sponsoring me on [GitHub Sponsors](https://github.com/sponsors/whitphx)!
-
-### RAKUDEJI Inc.
-
-[<img src="https://imagedelivery.net/uODi9j-67fGrJlC0UtMj5w/3c47faee-8dab-41fa-ded6-681bdc3e9500/desktop" height="50" >](https://rakudeji.com/)
-
-They are sponsoring me on [GitHub Sponsors](https://github.com/sponsors/whitphx)!
-
 ## Support the project
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/D1D2ERWFG)

--- a/cspell.json
+++ b/cspell.json
@@ -153,7 +153,6 @@
     "Xuan",
     "Stéphane",
     "Magnenat",
-    "RAKUDEJI",
     "fxxu",
     "dorny",
     // misc

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -78,23 +78,9 @@ import { Image } from "astro:assets";
       <img src="https://streamlit.io/images/brand/streamlit-mark-color.png" alt="Streamlit" class="sponsor-logo h-100" />
     </a>
     <a href="https://www.snowflake.com/" target="_blank" rel="noopener noreferrer">
-      <img src="https://docs.snowflake.com/_images/logo-snowflake-sans-text.png" alt="Snowflake" class="sponsor-logo h-100" />
+      <img src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" alt="Snowflake" class="sponsor-logo h-100" />
     </a>
   </div>
-
-<div class="sponsor-tier tier-2">
-  <a
-    href="https://www.testmuai.com/?utm_medium=sponsor&utm_source=stlite"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    <img
-      src="https://assets.testmuai.com/resources/images/logos/black-logo.png"
-      alt="TestMu AI"
-      class="sponsor-logo h-72"
-    />
-  </a>
-</div>
 
   <div class="sponsor-tier tier-3">
     <a href="https://hal9.com/" target="_blank" rel="noopener noreferrer">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -70,36 +70,6 @@ import { Image } from "astro:assets";
   </Card>
 </CardGrid>
 
-## Sponsors
-
-<div class="sponsors-layout">
-  <div class="sponsor-tier tier-1">
-    <a href="https://streamlit.io/" target="_blank" rel="noopener noreferrer">
-      <img src="https://streamlit.io/images/brand/streamlit-mark-color.png" alt="Streamlit" class="sponsor-logo h-100" />
-    </a>
-    <a href="https://www.snowflake.com/" target="_blank" rel="noopener noreferrer">
-      <img src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" alt="Snowflake" class="sponsor-logo h-100" />
-    </a>
-  </div>
-
-  <div class="sponsor-tier tier-3">
-    <a href="https://hal9.com/" target="_blank" rel="noopener noreferrer">
-      <img src="https://hal9.com/logo/hal9-square-black.png" alt="Hal9" class="sponsor-logo h-50" />
-    </a>
-    <a href="https://rakudeji.com/" target="_blank" rel="noopener noreferrer">
-      <img src="https://imagedelivery.net/uODi9j-67fGrJlC0UtMj5w/3c47faee-8dab-41fa-ded6-681bdc3e9500/desktop" alt="RAKUDEJI" class="sponsor-logo h-50" />
-    </a>
-  </div>
-</div>
-
-<div class="sponsors-footer">
-  <p>
-    They are sponsoring me on{" "}
-    <a href="https://github.com/sponsors/whitphx">GitHub Sponsors</a>!{" "}
-    <a href="#support-the-project">Support the project</a>.
-  </p>
-</div>
-
 ## Resources
 
 - [📖 Streamlit meets WebAssembly - stlite, by whitphx](https://www.whitphx.info/posts/20221104-streamlit-wasm-stlite/): A blog post covering from some technical surveys to the usages of the online editor _Stlite Sharing_, self-hosting apps, and the desktop app bundler.

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -73,20 +73,9 @@
   width: auto;
 }
 
-.h-72 {
-  height: 72px;
-  width: auto;
-}
-
 .h-50 {
   height: 50px;
   width: auto;
-}
-
-/* Specific fix for Snowflake logo which is wide */
-img[alt="Snowflake"].h-100 {
-  /* Maintain aspect ratio but constrain height */
-  height: 100px;
 }
 
 /* Support links layout */

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -36,48 +36,6 @@
   font-size: 0 !important;
 }
 
-/* Sponsor Layout Styles */
-.sponsors-layout {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2rem;
-  margin: 2rem 0;
-}
-
-.sponsor-tier {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  gap: 2rem;
-}
-
-.sponsor-logo {
-  display: block;
-  object-fit: contain;
-  /* Ensure visibility on dark mode - add white bg and padding */
-  background-color: #ffffff;
-  padding: 10px;
-  border-radius: 8px;
-  transition: transform 0.2s;
-}
-
-.sponsor-logo:hover {
-  transform: scale(1.05);
-}
-
-.h-100 {
-  height: 100px;
-  width: auto;
-}
-
-.h-50 {
-  height: 50px;
-  width: auto;
-}
-
 /* Support links layout */
 .support-links {
   display: flex;
@@ -85,13 +43,6 @@
   gap: 1rem;
   align-items: center;
   margin-top: 1rem;
-}
-
-.sponsors-footer {
-  text-align: center;
-  margin-top: 2rem;
-  font-size: 0.9rem;
-  opacity: 0.8;
 }
 
 /* Custom Homepage Hero Layout */


### PR DESCRIPTION
None of the sponsors listed on the README and the docs landing page are current, so the section no longer reflects who supports the project.

This removes the sponsors section from both pages, together with the CSS that existed only to lay out the sponsor logos. The separate "Support the project" section stays, since its GitHub Sponsors badge invites new sponsorship rather than listing existing sponsors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed sponsor listings, logos, links, and sponsorship messaging from the README and documentation homepage.
  * Retained the general “Support the project” section.
* **Style**
  * Removed styling used exclusively for sponsor layouts and sponsorship footers.
* **Chores**
  * Removed an obsolete custom dictionary entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->