### PR TITLE
refactor(cloudflare): construct response `Headers` directly

### DIFF
--- a/packages/cloudflare/py/stlite_cloudflare/adapter.py
+++ b/packages/cloudflare/py/stlite_cloudflare/adapter.py
@@ -51,7 +51,7 @@ async def run_http_asgi(app: AsgiApp, request: Any) -> Any:
         return js.Response.new(
             response_body,
             status=status,
-            headers=_to_js_headers(headers),
+            headers=js.Headers.new(headers),
         )
 
     async def send(message: AsgiMessage) -> None:
@@ -196,15 +196,6 @@ def _decode_response_headers(
         (to_bytes(name).decode("latin-1"), to_bytes(value).decode("latin-1"))
         for name, value in headers
     ]
-
-
-def _to_js_headers(headers: list[tuple[str, str]]) -> Any:
-    # Headers.new(sequence-of-pairs) keeps repeated names (multiple
-    # Set-Cookie); a plain-object conversion would collapse them.
-    import js
-    from pyodide.ffi import to_js
-
-    return js.Headers.new(to_js(headers))
 
 
 def iter_header_pairs(headers: Any) -> Iterable[tuple[Any, Any]]:


### PR DESCRIPTION
## Summary

The ASGI bridge converted decoded response headers with `to_js` before constructing a Fetch `Headers` object, even though Pyodide passes this sequence directly. This constructs `Headers` at the response call site and removes the single-use conversion helper while preserving repeated response headers such as `Set-Cookie`.

## Reproduction steps

Not applicable. This is a behavior-preserving refactor.

## Screenshots

Not applicable. There are no UI changes.

## Related issue

Fixes #2095

## Credit

Credit to Ryan Kang for [the review advice on cloudflare/workers-py#167](https://github.com/cloudflare/workers-py/pull/167#discussion_r3702053919) that identified this simplification.

`uv run pytest tests/test_adapter.py` in `packages/cloudflare` runs the focused adapter tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response header handling for Cloudflare deployments.
  * Ensured decoded headers are passed correctly when constructing responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->