### PR TITLE
chore(cloudflare): add the changeset for the response `Headers` refactor

### DIFF
--- a/.changeset/cloudflare-response-headers.md
+++ b/.changeset/cloudflare-response-headers.md
@@ -1,0 +1,5 @@
+---
+"@stlite/cloudflare": patch
+---
+
+Construct the Fetch `Headers` object directly from the ASGI response headers, preserving repeated headers such as `Set-Cookie`.

--- a/.changeset/cloudflare-response-headers.md
+++ b/.changeset/cloudflare-response-headers.md
@@ -2,4 +2,4 @@
 "@stlite/cloudflare": patch
 ---
 
-Construct the Fetch `Headers` object directly from the ASGI response headers, preserving repeated headers such as `Set-Cookie`.
+Construct the response `Headers` in the Cloudflare Workers adapter by passing the ASGI header pairs to `js.Headers.new()` directly, dropping the intermediate conversion. No behavior change.


### PR DESCRIPTION
The `Headers` refactor in #2096 landed without a changeset fragment, so it is not queued for release. This adds a patch changeset for `@stlite/cloudflare`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare integration release notes to reflect improved handling of response headers.
  * Response headers can now be constructed directly from ASGI header pairs without an intermediate conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->