### PR TITLE
docs: restore the sponsors section for Streamlit (Snowflake) and TestMu AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ Image processing with OpenCV works on the client side.
 
 ### Streamlit (Snowflake)
 
-[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img alt="Snowflake" src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
+[<img alt="Streamlit" src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img alt="Snowflake" src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
 
 ### TestMu AI
 

--- a/README.md
+++ b/README.md
@@ -640,6 +640,16 @@ Image processing with OpenCV works on the client side.
 
 </details>
 
+## Sponsors
+
+### Streamlit (Snowflake)
+
+[<img src="https://streamlit.io/images/brand/streamlit-mark-color.png" height="100" />](https://streamlit.io/) [<img alt="Snowflake" src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" height="100" />](https://www.snowflake.com/)
+
+### TestMu AI
+
+[<picture><source media="(prefers-color-scheme: dark)" srcset="https://assets.testmuai.com/resources/images/logos/white-logo.png"><source media="(prefers-color-scheme: light)" srcset="https://assets.testmuai.com/resources/images/logos/black-logo.png"><img alt="TestMu AI logo" src="https://assets.testmuai.com/resources/images/logos/white-logo.png" height="85"></picture>](https://www.testmuai.com/?utm_medium=sponsor&utm_source=stlite)
+
 ## Support the project
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/D1D2ERWFG)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -70,6 +70,33 @@ import { Image } from "astro:assets";
   </Card>
 </CardGrid>
 
+## Sponsors
+
+<div class="sponsors-layout">
+  <div class="sponsor-tier">
+    <a href="https://streamlit.io/" target="_blank" rel="noopener noreferrer">
+      <img src="https://streamlit.io/images/brand/streamlit-mark-color.png" alt="Streamlit" class="sponsor-logo h-100" />
+    </a>
+    <a href="https://www.snowflake.com/" target="_blank" rel="noopener noreferrer">
+      <img src="https://docs.snowflake.com/images/favicon/apple-touch-icon.png" alt="Snowflake" class="sponsor-logo h-100" />
+    </a>
+  </div>
+
+  <div class="sponsor-tier">
+    <a
+      href="https://www.testmuai.com/?utm_medium=sponsor&utm_source=stlite"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img
+        src="https://assets.testmuai.com/resources/images/logos/black-logo.png"
+        alt="TestMu AI"
+        class="sponsor-logo h-72"
+      />
+    </a>
+  </div>
+</div>
+
 ## Resources
 
 - [📖 Streamlit meets WebAssembly - stlite, by whitphx](https://www.whitphx.info/posts/20221104-streamlit-wasm-stlite/): A blog post covering from some technical surveys to the usages of the online editor _Stlite Sharing_, self-hosting apps, and the desktop app bundler.

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -36,6 +36,48 @@
   font-size: 0 !important;
 }
 
+/* Sponsor Layout Styles */
+.sponsors-layout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.sponsor-tier {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+}
+
+.sponsor-logo {
+  display: block;
+  object-fit: contain;
+  /* Ensure visibility on dark mode - add white bg and padding */
+  background-color: #ffffff;
+  padding: 10px;
+  border-radius: 8px;
+  transition: transform 0.2s;
+}
+
+.sponsor-logo:hover {
+  transform: scale(1.05);
+}
+
+.h-100 {
+  height: 100px;
+  width: auto;
+}
+
+.h-72 {
+  height: 72px;
+  width: auto;
+}
+
 /* Support links layout */
 .support-links {
   display: flex;


### PR DESCRIPTION
PR #2092 removed the Sponsors section from the README and the docs landing page because none of the listed sponsorships were current. The Streamlit (Snowflake) and TestMu AI sponsorships have since resumed.

This restores the section with those two entries, along with the CSS that lays out the logos. Hal9 and RAKUDEJI stay removed, and the Snowflake logo moves to `https://docs.snowflake.com/images/favicon/apple-touch-icon.png` because the previous `https://docs.snowflake.com/_images/logo-snowflake-sans-text.png` now 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Sponsors section to the README and documentation site.
  * Included linked sponsor logos for Streamlit, Snowflake, and TestMu AI.
  * Added responsive styling for organized sponsor displays and logo presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->