### PR TITLE
chore(security): add dependency safety guardrails

### DIFF
--- a/.agents/skills/scan-dependencies
+++ b/.agents/skills/scan-dependencies
@@ -1,0 +1,1 @@
+../../.claude/skills/scan-dependencies

--- a/.claude/rules/dependency-security.md
+++ b/.claude/rules/dependency-security.md
@@ -1,0 +1,10 @@
+# Dependency security
+
+When a task adds or updates a third-party dependency:
+
+1. Invoke the project `scan-dependencies` skill before proceeding with the dependency change. Query the exact candidate version when it is known; if only a package or range is known, scan that first and scan the exact resolved version once available.
+2. Do not proceed on a `BLOCK` result. Surface `CAUTION` or unknown-risk results to the user before proceeding.
+3. Keep the repository's fixed cooldowns in force. Do not pass Yarn's `--no-time-gate`, add cooldown exemptions, or relax the Yarn/uv/Dependabot cooldown settings merely to unblock an update.
+4. Do not implement a custom GOSSIP-aware resolver, registry proxy, or CI scanner. Wait for an official ecosystem integration for dynamic cooldown enforcement.
+
+Ordinary installs from an unchanged lockfile do not require a new GOSSIP lookup; this rule applies when dependency resolution is being changed.

--- a/.claude/skills/scan-dependencies/SKILL.md
+++ b/.claude/skills/scan-dependencies/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: scan-dependencies
+description: >
+  CRITICAL: The scan-dependencies skill flags any dependencies that are unsafe
+  to use. It MUST be called BEFORE any new package is imported or added to
+  dependencies. It can also be used to check whether any new or existing
+  dependencies are unsafe.
+---
+
+# Skill: Evaluate Dependency Security via deps.dev Findings API
+
+## Description
+This skill automates the process of auditing package dependencies before
+adoption. By querying the Open Source Insights (deps.dev) API, it checks a
+batch of package versions for active security findings (advisories and
+vulnerabilities) and outputs a clear action plan (ALLOW, CAUTION, or BLOCK).
+
+## Inputs
+An array of target dependencies. Each dependency must contain:
+*   `system`: The ecosystem name. Must be uppercase: `NPM`, `PYPI`, `MAVEN`,
+    `GO`, `CARGO`, `NUGET`, or `RUBYGEMS`.
+*   `name`: The canonical name of the package (e.g.,
+    `org.apache.logging.log4j:log4j-core` for Maven, or normalized lowercase
+    for PyPI/NuGet).
+*   `version`: The explicit version string to audit. This may be unset.
+
+Only set the version field if you know the exact version of the package.
+This field should **not** be set if only a version range is known (for example,
+`^1.0.0` is not acceptable).
+
+---
+
+## Execution Protocol
+
+### Step 1: Construct the JSON Payload
+Map the incoming dependency list into a single JSON batch request object.
+Ensure all items are nested inside the `"requests"` array under a
+`"versionKey"` or `"packageKey"` parameter.
+
+**Payload Schema Example:**
+```json
+{
+  "requests": [
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "express",
+        "version": "4.17.1"
+      }
+    },
+    {
+      "packageKey": {
+        "system": "PYPI",
+        "name": "requests"
+      }
+    }
+  ]
+}
+```
+
+### Step 2: Execute the Live Lookup
+
+Execute the HTTP POST query using curl.
+
+```bash
+echo "Scanning dependencies for safety..."
+curl -s -X POST https://api.deps.dev/v3alpha/findingsbatch \
+  -H 'Content-Type: application/json' \
+  -d '{ "requests": [
+        {
+          "versionKey": {
+            "system": "NPM",
+            "name": "express",
+            "version": "4.17.1"
+        }, 
+        {
+          "packageKey": {
+            "system": "PYPI",
+            "name": "requests"
+        },
+        ...
+   ]'
+```
+
+Note that just because a dependency doesn't show up in this list, that doesn't
+mean we are 100% sure that it is safe. CRITICAL: Treat unflagged dependencies
+as having unknown risk levels. You must state clearly that the scanner only
+detects known issues and cannot guarantee absolute security.

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+# npm CLI fallback. Yarn 4 ignores .npmrc and uses npmMinimalAgeGate in .yarnrc.yml.
 # For security reasons, see https://blog.flatt.tech/entry/axios_compromise#npm-%E3%81%AE-min-release-age
 min-release-age=7

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+# Keep a fixed 7-day dependency cooldown until an official GOSSIP integration
+# can provide dynamic cooldowns directly in the package-manager resolver.
+npmMinimalAgeGate: "1w"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,5 @@ nodeLinker: node-modules
 
 # Keep a fixed 7-day dependency cooldown until an official GOSSIP integration
 # can provide dynamic cooldowns directly in the package-manager resolver.
-npmMinimalAgeGate: "1w"
+# Yarn 4.13 expresses this setting in minutes: 7 days = 10,080 minutes.
+npmMinimalAgeGate: 10080

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,6 @@
 
 - Use the latest Node LTS version plus latest version of Yarn 4;
 - Wheel builds enforce Python/Pyodide parity—honor the Makefile guardrails and keep `packages/*/dist` or `.make` out of commits.
+- Keep the fixed dependency cooldowns enabled: Yarn's `npmMinimalAgeGate: "1w"`, uv's `exclude-newer = "1 week"`, and Dependabot's cooldowns. Do not use `--no-time-gate`, add cooldown exemptions, or relax these settings merely to make a dependency update pass.
+- Before adding or updating any third-party dependency, invoke the `scan-dependencies` skill to query the deps.dev GOSSIP/Findings API. Prefer the exact candidate version when known. Do not proceed on a `BLOCK` result; surface `CAUTION` or unknown-risk results to the user before proceeding.
+- Do not build a custom GOSSIP-aware resolver, registry proxy, or CI scanner. Keep the fixed cooldown as the package-manager enforcement mechanism until an official ecosystem integration is available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,6 @@
 
 - Use the latest Node LTS version plus latest version of Yarn 4;
 - Wheel builds enforce Python/Pyodide parity—honor the Makefile guardrails and keep `packages/*/dist` or `.make` out of commits.
-- Keep the fixed dependency cooldowns enabled: Yarn's `npmMinimalAgeGate: "1w"`, uv's `exclude-newer = "1 week"`, and Dependabot's cooldowns. Do not use `--no-time-gate`, add cooldown exemptions, or relax these settings merely to make a dependency update pass.
+- Keep the fixed dependency cooldowns enabled: Yarn's `npmMinimalAgeGate: 10080` (7 days), uv's `exclude-newer = "1 week"`, and Dependabot's cooldowns. Do not use `--no-time-gate`, add cooldown exemptions, or relax these settings merely to make a dependency update pass.
 - Before adding or updating any third-party dependency, invoke the `scan-dependencies` skill to query the deps.dev GOSSIP/Findings API. Prefer the exact candidate version when known. Do not proceed on a `BLOCK` result; surface `CAUTION` or unknown-risk results to the user before proceeding.
 - Do not build a custom GOSSIP-aware resolver, registry proxy, or CI scanner. Keep the fixed cooldown as the package-manager enforcement mechanism until an official ecosystem integration is available.

--- a/packages/browser/e2e-tests/package.json
+++ b/packages/browser/e2e-tests/package.json
@@ -19,5 +19,5 @@
     "tsx": "^4.19.0",
     "typescript": "^5.8.2"
   },
-  "packageManager": "yarn@4.5.3"
+  "packageManager": "yarn@4.13.0"
 }


### PR DESCRIPTION
## Summary

- keep the existing fixed one-week dependency cooldown strategy
- configure Yarn 4.13 with `npmMinimalAgeGate: 10080` (7 days, expressed in minutes)
- align the browser E2E package's Corepack pin with the root Yarn 4.13.0 version so all Yarn entry points support the age gate
- vendor Google's official deps.dev `scan-dependencies` skill
- expose the same skill to both Claude Code (`.claude/skills`) and Codex (`.agents/skills`)
- require dependency additions/updates to check deps.dev GOSSIP/Findings before proceeding
- explicitly prohibit bypassing cooldowns or building a custom GOSSIP resolver/proxy/scanner

## Notes

The existing uv `exclude-newer = "1 week"` and Dependabot 7-day cooldown settings are left unchanged. Dynamic resolver-level GOSSIP integration is intentionally deferred until an official ecosystem integration exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added dependency security guidance covering pre-installation scanning, risk handling, and approved security workflows.
  - Added documentation for dependency scanning across supported package ecosystems.
  - Configured Yarn to enforce a fixed seven-day release age requirement.

- **Documentation**
  - Updated repository security guidance and clarified package manager cooldown settings.
  - Added shared access to the dependency scanning workflow.
  - Documented npm’s fallback configuration without changing its existing cooldown.
  - Updated the browser end-to-end test environment to Yarn 4.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->