### PR TITLE
ci: add aggregate status checks and widen the `changes` path filter

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -12,6 +12,13 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  # Let the `labeled` run cancel the `opened` one still in flight. Without
+  # this, a PR labeled `skip-changeset` after it was opened keeps the first
+  # run's failure on the commit even though the bypass now applies.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -400,7 +400,7 @@ jobs:
   # The counterpart of `test-build-all-green` in `test-build.yml`, which
   # carries the rationale for both.
   e2e-all-green:
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs:
       [
         wait-for-build,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -397,9 +397,8 @@ jobs:
         run: npm run app:dir
         working-directory: ${{ runner.temp }}/sample_app
 
-  # The counterpart of `test-build-all-green`. Naming these jobs individually
-  # would be especially brittle: the generated names of the sharded and
-  # per-OS matrix jobs above move whenever the matrix does.
+  # The counterpart of `test-build-all-green` in `test-build.yml`, which
+  # carries the rationale for both.
   e2e-all-green:
     if: ${{ always() }}
     needs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -396,3 +396,25 @@ jobs:
       - name: Check if electron-builder works
         run: npm run app:dir
         working-directory: ${{ runner.temp }}/sample_app
+
+  # The counterpart of `test-build-all-green`. Naming these jobs individually
+  # would be especially brittle: the generated names of the sharded and
+  # per-OS matrix jobs above move whenever the matrix does.
+  e2e-all-green:
+    if: ${{ always() }}
+    needs:
+      [
+        wait-for-build,
+        e2e-browser,
+        merge-e2e-browser-reports,
+        e2e-react,
+        e2e-desktop,
+        e2e-desktop-cli,
+      ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -109,18 +109,18 @@ jobs:
   changes: # See https://github.com/dorny/paths-filter#examples
     runs-on: ubuntu-latest
     outputs:
-      common: ${{ steps.filter.outputs.common == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      kernel: ${{ steps.filter.outputs.kernel == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      # stlite-lib: ${{ steps.filter.outputs.stlite-lib == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      common: ${{ steps.filter.outputs.common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      kernel: ${{ steps.filter.outputs.kernel == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      # stlite-lib: ${{ steps.filter.outputs.stlite-lib == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       stlite-lib: "true" # This step does not detect changes in the `streamlit` submodule that is needed to trigger the test-stlite-lib job (https://github.com/dorny/paths-filter/issues/143), so skip checking and make it always return true as a workaround.
-      react: ${{ steps.filter.outputs.react == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      browser: ${{ steps.filter.outputs.browser == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      sharing: ${{ steps.filter.outputs.sharing == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      sharing-editor: ${{ steps.filter.outputs.sharing-editor == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      sharing-common: ${{ steps.filter.outputs.sharing-common == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      desktop: ${{ steps.filter.outputs.desktop == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      cli: ${{ steps.filter.outputs.cli == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.gha == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      react: ${{ steps.filter.outputs.react == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      browser: ${{ steps.filter.outputs.browser == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      sharing: ${{ steps.filter.outputs.sharing == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      sharing-editor: ${{ steps.filter.outputs.sharing-editor == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      sharing-common: ${{ steps.filter.outputs.sharing-common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      desktop: ${{ steps.filter.outputs.desktop == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      cli: ${{ steps.filter.outputs.cli == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -129,9 +129,23 @@ jobs:
         id: filter
         with:
           filters: |
-            gha:
+            # Files no single package owns, so a change to any of them turns
+            # on every per-package job below. The workspace-wide lockfiles are
+            # why this matters most: one bump can shift resolution for any
+            # package, not only the one whose manifest changed.
+            global:
               - '.github/workflows/**/*'
               - '.github/actions/**/*'
+              - 'Makefile'
+              - 'tsconfig.json'
+              - '.nvmrc'
+              - '.python-version'
+              - 'package.json'
+              - 'yarn.lock'
+              - '.yarnrc.yml'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'packages/tooling/**/*'
             common:
               - 'packages/common/**/*'
             kernel:
@@ -1199,3 +1213,63 @@ jobs:
         with:
           subject-path: docs/dist
         continue-on-error: true
+
+  # A single status check for branch protection to require. Requiring the
+  # jobs above by name instead would silently leave every newly added job
+  # unrequired, and would break whenever a matrix job's generated name
+  # changes.
+  test-build-all-green:
+    if: ${{ always() }}
+    needs:
+      [
+        set-build-info,
+        changesets,
+        changes,
+        test-build-common,
+        test-kernel,
+        test-stlite-lib,
+        test-browser,
+        test-react,
+        test-sharing,
+        test-sharing-editor,
+        test-sharing-common,
+        test-desktop,
+        test-cli,
+        test-cloudflare,
+        test-cloudflare-windows,
+        build-browser,
+        build-react,
+        build-sharing,
+        build-sharing-editor,
+        build-desktop,
+        build-cli,
+        build-cloudflare,
+        verify-cloudflare-standalone,
+        build-docs,
+      ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # `allowed-skips` lists the jobs that legitimately don't run on every
+      # event. A skip anywhere else (a `needs` typo, a job dropped from the
+      # graph) fails here instead of passing silently.
+      - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: >-
+            changesets,
+            test-build-common,
+            test-kernel,
+            test-stlite-lib,
+            test-browser,
+            test-react,
+            test-sharing,
+            test-sharing-editor,
+            test-sharing-common,
+            test-desktop,
+            test-cli,
+            test-cloudflare,
+            test-cloudflare-windows,
+            build-cloudflare,
+            verify-cloudflare-standalone

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -129,10 +129,9 @@ jobs:
         id: filter
         with:
           filters: |
-            # Files no single package owns, so a change to any of them turns
-            # on every per-package job below. The workspace-wide lockfiles are
-            # why this matters most: one bump can shift resolution for any
-            # package, not only the one whose manifest changed.
+            # The lockfiles are why this reaches past the obvious: a single
+            # bump can shift resolution for any package, not only the one
+            # whose manifest changed.
             global:
               - '.github/workflows/**/*'
               - '.github/actions/**/*'
@@ -143,6 +142,9 @@ jobs:
               - 'package.json'
               - 'yarn.lock'
               - '.yarnrc.yml'
+              - '.npmrc'
+              - '.oxlintrc.json'
+              - '.oxfmtrc.json'
               - 'pyproject.toml'
               - 'uv.lock'
               - 'packages/tooling/**/*'
@@ -1219,6 +1221,9 @@ jobs:
   # unrequired, and would break whenever a matrix job's generated name
   # changes.
   test-build-all-green:
+    # `always()`, not the `! failure()` the build jobs use: a skipped check
+    # reports as neutral to branch protection, so the gate has to run and
+    # fail rather than skip itself.
     if: ${{ always() }}
     needs:
       [
@@ -1251,9 +1256,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # `allowed-skips` lists the jobs that legitimately don't run on every
-      # event. A skip anywhere else (a `needs` typo, a job dropped from the
-      # graph) fails here instead of passing silently.
+      # A skip outside `allowed-skips` (a `needs` typo, a job dropped from
+      # the graph) fails here instead of passing silently.
       - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
         with:
           jobs: ${{ toJSON(needs) }}
@@ -1261,7 +1265,6 @@ jobs:
             changesets,
             test-build-common,
             test-kernel,
-            test-stlite-lib,
             test-browser,
             test-react,
             test-sharing,

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1221,10 +1221,11 @@ jobs:
   # unrequired, and would break whenever a matrix job's generated name
   # changes.
   test-build-all-green:
-    # `always()`, not the `! failure()` the build jobs use: a skipped check
-    # reports as neutral to branch protection, so the gate has to run and
-    # fail rather than skip itself.
-    if: ${{ always() }}
+    # Not `always()`: that reports a failure for every run superseded by
+    # `cancel-in-progress`, which is every push to a PR. `!cancelled()` still
+    # runs the gate when a job above failed or skipped, which is the case
+    # that has to be caught.
+    if: ${{ !cancelled() }}
     needs:
       [
         set-build-info,


### PR DESCRIPTION
Branch protection has no stable set of job names to require in this repo. `test-build.yml` skips most of its per-package jobs through the `changes` filter, and both workflows generate matrix job names that move whenever the matrix does, so requiring jobs by name would leave every newly added job unrequired and break on the next matrix change. This is groundwork for gating Dependabot auto-merge on CI.

This adds a `test-build-all-green` job to `test-build.yml` and an `e2e-all-green` job to `e2e.yml`, each reporting on every other job in its workflow, so `main` can require one context per workflow. `allowed-skips` names the jobs that legitimately don't run on every event, so a job dropping out of the graph fails the gate instead of passing silently.

The second change closes a gap that gate would otherwise lock in. The `changes` filter had no pattern for files no single package owns, so a bump touching only the root `yarn.lock` matched nothing and every unit-test job skipped, even though that lockfile resolves dependencies for the whole workspace. The same held for the root lint configs that every package's `check:lint` and `check:format` read. The `gha` filter becomes `global` and covers the shared lockfiles, manifests, lint and install configs, toolchain pins, and `packages/tooling`. The cost is that any PR touching `yarn.lock` now runs the full matrix rather than the jobs for the package whose manifest changed.

The third change stops a check going red when it shouldn't. Labeling a PR `skip-changeset` after opening it starts a second `changeset-check` run that takes the bypass, while the first run keeps going and leaves its failure on the commit. A per-PR concurrency group with `cancel-in-progress`, matching what `test-build.yml` and `e2e.yml` already do, lets the `labeled` run supersede the `opened` one.

Branch protection still has to be pointed at the two new contexts, which is a repository setting. On `main` the gate takes effect immediately either way: it is a job of the `Test and Build` run, so a gate failure flips that run's conclusion and holds back `postbuild.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated validation by cancelling outdated, duplicate workflow runs.
  - Added consolidated success checks for end-to-end testing and test/build pipelines.
  - Expanded change detection to cover repository-wide configuration and tooling updates.
  - Improved reporting for workflows where certain checks are intentionally skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->