### PR TITLE
test(browser): match the selectbox dropdown by `data-testid` and the `option` role

### DIFF
--- a/packages/browser/e2e-tests/tests/custom-element.test.ts
+++ b/packages/browser/e2e-tests/tests/custom-element.test.ts
@@ -22,14 +22,19 @@ test.describe("Custom Element Stlite Browser Test", () => {
 
     // Click the selectbox to open the dropdown
     await selectbox.click();
+    // ArrowDown also opens it, in case the click did not register as a
+    // pointer open. On an already-open dropdown it only moves the highlight,
+    // which the selection below does not depend on.
+    await selectbox.press("ArrowDown");
 
     // Wait for the dropdown to appear
-    await expect(
-      page.locator('ul[data-testid="stSelectboxVirtualDropdown"]'),
-    ).toBeVisible();
+    const dropdown = page.getByTestId("stSelectboxVirtualDropdown");
+    await expect(dropdown).toBeVisible();
 
     // Select a different option
-    await page.locator('li:has-text("Mobile phone")').click();
+    await dropdown
+      .getByRole("option", { name: "Mobile phone", exact: true })
+      .click();
 
     // Check if the selection is updated
     await expect(


### PR DESCRIPTION
The custom element e2e test located the selectbox dropdown as `ul[data-testid="stSelectboxVirtualDropdown"]` and its options as `li`, which describes Base Web's markup rather than the dropdown itself. Streamlit 1.62.0 finishes removing Base Web and moves that test id onto a `react-aria-components` popover whose options are `div[role="option"]`, so both locators stop matching.

The test now finds the dropdown by test id and the option by its `option` role, which holds for either markup. That version also opens the dropdown through explicit handlers (`menuTrigger="manual"`), where a pointer open depends on `pointerDown` arriving before focus, so the test presses `ArrowDown` as well.

This has to land before the Streamlit rebase in https://github.com/whitphx/stlite/pull/2110 rather than inside it. `e2e-browser-browserstack` runs from `workflow_run`, where `actions/checkout` gets the default branch, so it pairs `main`'s copy of the tests with the `@stlite/browser` artifact built from the pull request under test. Until this locator change is on `main`, that job drives the new dropdown with the old locators, and no change on the rebase branch can turn it green.

`yarn test` in `packages/browser/e2e-tests` runs it; the four `e2e-browser` shards exercise it here against the current Base Web dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhaUoun8FuKk2CmzWLmjZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhaUoun8FuKk2CmzWLmjZY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved custom selectbox end-to-end test reliability by supporting keyboard-based dropdown opening.
  * Updated dropdown and option targeting to use more precise accessibility and test identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->