### PR TITLE
ci: group Dependabot updates and auto-merge non-major dev/Actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      # `dependabot-auto-merge.yml` keys on this group's name.
       github-actions:
         patterns: ["*"]
         update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,50 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      # `dependabot-auto-merge.yml` keys on this group's name.
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      # Production and development stay in separate groups because
+      # `dependabot/fetch-metadata` reports a group holding both as
+      # `direct:production`, which would keep every development bump in it
+      # from auto-merging.
+      #
+      # Majors match no group, so they arrive one PR at a time and are left
+      # for a human.
+      npm-production:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      npm-development:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "pip"
     directory: "/packages/kernel/py/stlite-lib"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      pip-production:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      pip-development:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,54 @@
+name: "Dependabot auto-merge"
+
+on:
+  pull_request_target:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    # Anyone can push a branch named to look like Dependabot's, so the author
+    # is what gates this job. Dependabot needs `pull_request_target` because
+    # on `pull_request` its token is read-only and cannot enable auto-merge.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      # No step checks out the head branch, and none should: under
+      # `pull_request_target` that would run the PR's own code alongside the
+      # write token above.
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        id: metadata
+
+      - name: Enable auto-merge
+        # CI builds every package and runs the E2E suites against those
+        # artifacts, which is the whole review for a development or Actions
+        # bump. A runtime dependency resolves on the user's machine instead,
+        # where that evidence does not reach, so those stay manual.
+        #
+        # Actions are matched by group rather than by ecosystem because
+        # Dependabot reports them as `direct:production`, the same value a
+        # runtime dependency carries. The group is defined in
+        # `.github/dependabot.yml`.
+        #
+        # `fetch-metadata` collapses a grouped PR to its riskiest member, so a
+        # group that picks up a production dependency or a major drops out of
+        # this condition instead of merging on the strength of the rest.
+        if: >-
+          ${{ steps.metadata.outputs.update-type != 'version-update:semver-major'
+          && (steps.metadata.outputs.dependency-group == 'github-actions'
+          || steps.metadata.outputs.dependency-type == 'direct:development') }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # `--auto` queues the merge behind the branch ruleset's required
+        # checks. A ruleset that requires none of them merges the PR the
+        # moment this runs, so the required contexts have to be in place
+        # before this workflow is.
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,14 @@ jobs:
     # Anyone can push a branch named to look like Dependabot's, so the author
     # is what gates this job. Dependabot needs `pull_request_target` because
     # on `pull_request` its token is read-only and cannot enable auto-merge.
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    #
+    # The commit count keeps a PR someone has already pushed to out of scope.
+    # `fetch-metadata` authenticates only the first commit of the branch, so
+    # without this a hand-written commit stacked on top would inherit
+    # Dependabot's signature and merge unreviewed.
+    if: >-
+      ${{ github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.commits == 1 }}
 
     runs-on: ubuntu-latest
 
@@ -32,17 +39,16 @@ jobs:
         # bump. A runtime dependency resolves on the user's machine instead,
         # where that evidence does not reach, so those stay manual.
         #
-        # Actions are matched by group rather than by ecosystem because
-        # Dependabot reports them as `direct:production`, the same value a
-        # runtime dependency carries. The group is defined in
-        # `.github/dependabot.yml`.
+        # Actions are matched by ecosystem rather than by dependency type
+        # because Dependabot reports them as `direct:production`, the same
+        # value a runtime dependency carries.
         #
         # `fetch-metadata` collapses a grouped PR to its riskiest member, so a
         # group that picks up a production dependency or a major drops out of
         # this condition instead of merging on the strength of the rest.
         if: >-
           ${{ steps.metadata.outputs.update-type != 'version-update:semver-major'
-          && (steps.metadata.outputs.dependency-group == 'github-actions'
+          && (steps.metadata.outputs.package-ecosystem == 'github_actions'
           || steps.metadata.outputs.dependency-type == 'direct:development') }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,8 @@
 name: "Dependabot auto-merge"
 
+# This workflow follows dependabot/fetch-metadata's own auto-merge example.
+# See https://github.com/dependabot/fetch-metadata/blob/25dd0e34f4fe68f24cc83900b1fe3fe149efef98/README.md#enabling-auto-merge
+
 on:
   pull_request_target:
     branches: ["main"]
@@ -57,4 +60,5 @@ jobs:
         # checks. A ruleset that requires none of them merges the PR the
         # moment this runs, so the required contexts have to be in place
         # before this workflow is.
+        # Ref: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request#enabling-auto-merge
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Dependabot opens a PR per dependency per day here, and every one waits on a human to click merge even when the change is a patch bump to a test runner. The volume is the cost, not the risk in the bumps themselves.

This adds `dependabot-auto-merge.yml`, which turns on GitHub's auto-merge for a Dependabot PR when the update is non-major and is either a development dependency or a GitHub Actions bump. Those are the updates CI can vouch for by itself: it builds every package and runs the E2E suites against those artifacts, so a green run is the whole review. A runtime dependency resolves on the user's machine, where that evidence does not reach, so it still waits for a person.

`dependabot.yml` moves from daily to weekly and groups the non-major updates, which is what makes the workflow worth having: one PR per group per week rather than one per dependency per day. Production and development are separate groups because `dependabot/fetch-metadata` reports a group holding both as `direct:production`, and a mixed group would keep every development bump in it from auto-merging. Majors match no group, so they keep arriving one at a time and stay manual. `devcontainers` is left ungrouped, since it updates rarely enough that batching it would not save a PR.

The guard is fail-closed on grouped PRs. `fetch-metadata` collapses a group to its riskiest member for both `update-type` and `dependency-type`, so a group that picks up a major or a production dependency falls out of the condition instead of merging on the strength of the rest. The job additionally requires the PR to carry a single commit, because `fetch-metadata` authenticates only the first commit of a branch and a commit stacked on top would otherwise inherit Dependabot's signature.

Two repository settings have to be in place before this merges. "Allow auto-merge" has to be on, or `gh pr merge --auto` fails and every Dependabot PR picks up a red check. The branch ruleset has to require `test-build-all-green` and `e2e-all-green`, because `--auto` queues the merge behind the required checks and a ruleset requiring none of them would merge each PR the moment the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MJczkH5wXK2Z87auu2w26

---
_Generated by [Claude Code](https://claude.ai/code/session_012MJczkH5wXK2Z87auu2w26)_