### PR TITLE
ci: push the Changesets release commit and tags with the Git CLI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -86,9 +86,12 @@ jobs:
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           publish-script: npm run changeset:release
-          # The action pushes through the GitHub API by default, and the Git tree API cannot
-          # represent the `streamlit` submodule's gitlink, so it rejects the release commit with
-          # "Unexpected executable file at streamlit". Push with the Git CLI instead.
+          # Pushing through the GitHub API (the default) builds the release commit with
+          # `@changesets/ghcommit`, which stats every path `git diff` reports as changed.
+          # CI leaves tracked content in the `streamlit` submodule modified, so that path is
+          # a directory, and its executable bits fail the library's non-executable check:
+          # "Unexpected executable file at streamlit". The Git CLI stages with `git add .`,
+          # which skips a submodule whose recorded commit has not moved.
           push-with-git-cli: true
           # PRs created using `GITHUB_TOKEN` don't trigger CI workflows, so we need to use a PAT or app token.
           # - The PAT should be fine-grained and its permissions are properly configured (R/W for Contents and Pull Requests).

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -62,8 +62,8 @@ jobs:
           # `fetch-depth: 0` is required to create tags for new releases by Changesets.
           fetch-depth: 0
           # `persist-credentials: false` keeps the checkout token out of the git config.
-          # The Changesets action pushes the release commit and tags through the GitHub API
-          # with the `github-token` below, so no git credentials are needed here.
+          # The Changesets action authenticates its own pushes with the `github-token` below,
+          # so no git credentials are needed here.
           persist-credentials: false
 
       - uses: ./.github/actions/init-all
@@ -86,6 +86,10 @@ jobs:
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           publish-script: npm run changeset:release
+          # The action pushes through the GitHub API by default, and the Git tree API cannot
+          # represent the `streamlit` submodule's gitlink, so it rejects the release commit with
+          # "Unexpected executable file at streamlit". Push with the Git CLI instead.
+          push-with-git-cli: true
           # PRs created using `GITHUB_TOKEN` don't trigger CI workflows, so we need to use a PAT or app token.
           # - The PAT should be fine-grained and its permissions are properly configured (R/W for Contents and Pull Requests).
           # - The app token should be generated using a GitHub App that has proper permissions (R/W for Contents and Pull Requests).

--- a/cspell.json
+++ b/cspell.json
@@ -119,6 +119,7 @@
     "superstruct",
     "styletron",
     "quasis",
+    "ghcommit",
     // react-icons
     "Twotone",
     // Technology


### PR DESCRIPTION
The `changesets` job has failed on every push to `main` since #2119, so the version PR (#2116) has not been updated since 2026-09-07 and `test-build-all-green` and the E2E workflow go red on every commit.

`changesets/action` v2 pushes the release commit through the GitHub API by default, which builds it with `@changesets/ghcommit`. That library stats every path `git diff --name-status` reports as changed, and CI leaves tracked content in the `streamlit` submodule modified, so it stats a directory and rejects it with `Unexpected executable file at streamlit` before any API call happens.

Setting `push-with-git-cli: true` restores the v1 push path, which stages with `git add .`. That skips a submodule whose recorded commit has not moved, and nothing in this job moves it.

The `changesets` job only runs on pushes to `main`, so CI here cannot exercise the fix; the next push to `main` after merge is the proof. This PR has no user-facing effect, so it carries no changeset fragment and needs the `skip-changeset` label to pass `changeset-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvW5oxgffuwHktsZCg5hYa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated release publishing to create release commits and tags more reliably.
  - Updated release workflow messaging to clarify how authentication is handled.
  - Added support for an additional terminology entry in spell-checking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->