### PR TITLE
fix(deps): wait for `parquet-wasm` before parsing a dataframe

### DIFF
--- a/.changeset/parquet-wasm-init-race.md
+++ b/.changeset/parquet-wasm-init-race.md
@@ -1,0 +1,11 @@
+---
+"@stlite/react": patch
+"@stlite/browser": patch
+"@stlite/desktop": patch
+"@stlite/sharing": patch
+"@stlite/cloudflare": patch
+---
+
+Wait for `parquet-wasm` to finish instantiating before parsing a dataframe.
+
+Stlite parses Arrow payloads through `parquet-wasm`, whose reader throws until its WebAssembly module is instantiated. The initializer was started but never awaited, so an app that rendered a dataframe or an Arrow-backed chart before the 5.5 MB module finished loading took the page down with `Cannot read properties of undefined (reading '__wbindgen_add_to_stack_pointer')`. Bundling the Python runtime into the Cloudflare Worker script made that the common case rather than a rare one, because the app now boots without waiting on a runtime download first.

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -115,38 +115,38 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       common: ${{ steps.filter.outputs.common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      kernel: ${{ steps.filter.outputs.kernel == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      kernel: ${{ steps.filter.outputs.kernel == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.moved == 'true' || env.RUN_ALL_TESTS == 'true' }}
       # stlite-lib: ${{ steps.filter.outputs.stlite-lib == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       stlite-lib: "true" # This step does not detect changes in the `streamlit` submodule that is needed to trigger the test-stlite-lib job (https://github.com/dorny/paths-filter/issues/143), so skip checking and make it always return true as a workaround.
-      react: ${{ steps.filter.outputs.react == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      react: ${{ steps.filter.outputs.react == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.moved == 'true' || env.RUN_ALL_TESTS == 'true' }}
       browser: ${{ steps.filter.outputs.browser == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       sharing: ${{ steps.filter.outputs.sharing == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       sharing-editor: ${{ steps.filter.outputs.sharing-editor == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       sharing-common: ${{ steps.filter.outputs.sharing-common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       desktop: ${{ steps.filter.outputs.desktop == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       cli: ${{ steps.filter.outputs.cli == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.changed == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.moved == 'true' || env.RUN_ALL_TESTS == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # `paths-filter` diffs with `--ignore-submodules=all`, so none of the
-      # filters below can ever see a `streamlit` bump
-      # (https://github.com/dorny/paths-filter/issues/143). The Cloudflare jobs
-      # build the frontend out of that submodule, so they have to run when its
-      # gitlink moves; comparing it against the base branch is the only way to
-      # notice. Pushes to the default branch run everything anyway.
+          # Reach back to both parents of the pull request's merge commit, so
+          # the step below can read the gitlink on either side of the change.
+          fetch-depth: 2
+      # The jobs gated on `kernel`, `react` and `cloudflare` build or typecheck
+      # the `streamlit` submodule's sources, so a gitlink move has to reach
+      # them, and `paths-filter` cannot see one (see the `stlite-lib` note
+      # above). An unreadable gitlink on either side leaves the two strings
+      # unequal, which runs those jobs rather than skipping them.
       - name: Check whether the streamlit submodule moved
+        # Pushes to the default branch run everything anyway.
         if: github.event_name == 'pull_request'
         id: streamlit-submodule
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
-          if [ "$(git rev-parse "FETCH_HEAD:streamlit")" = "$(git rev-parse "HEAD:streamlit")" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          if [ "$(git rev-parse 'HEAD^1:streamlit')" = "$(git rev-parse 'HEAD^2:streamlit')" ]; then
+            echo "moved=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "moved=true" >> "$GITHUB_OUTPUT"
           fi
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -115,39 +115,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       common: ${{ steps.filter.outputs.common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      kernel: ${{ steps.filter.outputs.kernel == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.moved == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      kernel: ${{ steps.filter.outputs.kernel == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       # stlite-lib: ${{ steps.filter.outputs.stlite-lib == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       stlite-lib: "true" # This step does not detect changes in the `streamlit` submodule that is needed to trigger the test-stlite-lib job (https://github.com/dorny/paths-filter/issues/143), so skip checking and make it always return true as a workaround.
-      react: ${{ steps.filter.outputs.react == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.moved == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      react: ${{ steps.filter.outputs.react == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       browser: ${{ steps.filter.outputs.browser == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       sharing: ${{ steps.filter.outputs.sharing == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       sharing-editor: ${{ steps.filter.outputs.sharing-editor == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       sharing-common: ${{ steps.filter.outputs.sharing-common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       desktop: ${{ steps.filter.outputs.desktop == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       cli: ${{ steps.filter.outputs.cli == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.moved == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # Reach back to both parents of the pull request's merge commit, so
-          # the step below can read the gitlink on either side of the change.
-          fetch-depth: 2
-      # The jobs gated on `kernel`, `react` and `cloudflare` build or typecheck
-      # the `streamlit` submodule's sources, so a gitlink move has to reach
-      # them, and `paths-filter` cannot see one (see the `stlite-lib` note
-      # above). An unreadable gitlink on either side leaves the two strings
-      # unequal, which runs those jobs rather than skipping them.
-      - name: Check whether the streamlit submodule moved
-        # Pushes to the default branch run everything anyway.
-        if: github.event_name == 'pull_request'
-        id: streamlit-submodule
-        run: |
-          if [ "$(git rev-parse 'HEAD^1:streamlit')" = "$(git rev-parse 'HEAD^2:streamlit')" ]; then
-            echo "moved=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "moved=true" >> "$GITHUB_OUTPUT"
-          fi
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
@@ -175,12 +157,18 @@ jobs:
               - 'packages/common/**/*'
             kernel:
               - 'packages/kernel/**/*'
+              # A submodule shows up as its gitlink's own path, so the pattern
+              # has to be the bare path; `streamlit/**/*` never matches,
+              # because the contents live in another repository and are never
+              # listed.
+              - 'streamlit'
               # - '!packages/kernel/py/**/*'  # Not supported by paths-filter now: https://github.com/dorny/paths-filter/issues/106
             # stlite-lib:  # We run this job anytime. See above.
             #   - 'packages/kernel/py/stlite-lib/**/*'
             #   - 'streamlit/**/*'
             react:
               - 'packages/react/**/*'
+              - 'streamlit'
             browser:
               - 'packages/browser/**/*'
             sharing:
@@ -198,6 +186,7 @@ jobs:
             cloudflare:
               - 'packages/cloudflare/**/*'
               - 'packages/app-packager/**/*'
+              - 'streamlit'
 
   test-build-common:
     needs: changes

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -125,11 +125,29 @@ jobs:
       sharing-common: ${{ steps.filter.outputs.sharing-common == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       desktop: ${{ steps.filter.outputs.desktop == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
       cli: ${{ steps.filter.outputs.cli == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
-      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || env.RUN_ALL_TESTS == 'true' }}
+      cloudflare: ${{ steps.filter.outputs.cloudflare == 'true' || steps.filter.outputs.global == 'true' || steps.streamlit-submodule.outputs.changed == 'true' || env.RUN_ALL_TESTS == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # `paths-filter` diffs with `--ignore-submodules=all`, so none of the
+      # filters below can ever see a `streamlit` bump
+      # (https://github.com/dorny/paths-filter/issues/143). The Cloudflare jobs
+      # build the frontend out of that submodule, so they have to run when its
+      # gitlink moves; comparing it against the base branch is the only way to
+      # notice. Pushes to the default branch run everything anyway.
+      - name: Check whether the streamlit submodule moved
+        if: github.event_name == 'pull_request'
+        id: streamlit-submodule
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          if [ "$(git rev-parse "FETCH_HEAD:streamlit")" = "$(git rev-parse "HEAD:streamlit")" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:

--- a/cspell.json
+++ b/cspell.json
@@ -123,6 +123,7 @@
     // react-icons
     "Twotone",
     // Technology
+    "wbindgen",
     "FOUC",
     "TTFB",
     "WEBVTT",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -16,7 +16,11 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es6",
+    // `arrowParseUtils.ts` in the submodule awaits the parquet-wasm
+    // initializer at the top level, which TypeScript only allows from
+    // es2017. Staying below es2022 keeps `useDefineForClassFields` off,
+    // so class-field semantics across the submodule sources do not move.
+    "target": "es2017",
     "types": ["vite/client", "vitest/globals"],
     // Set the `paths` same as `streamlit/frontend/app/tsconfig.json`, https://github.com/streamlit/streamlit/blob/1.44.1/frontend/app/tsconfig.json#L5-L9.
     "paths": {


### PR DESCRIPTION
`verify-cloudflare-standalone` has failed on every push to `main` since #2115. The smoke test opens the hello sample's DataFrame page and the browser throws `TypeError: Cannot read properties of undefined (reading '__wbindgen_add_to_stack_pointer')` out of `ArrowVegaLiteChart`.

Stlite parses Arrow payloads with `parquet-wasm`, whose reader reads the WebAssembly exports directly and throws until the module is instantiated. The fork started the initializer without awaiting it, so readiness depended entirely on something else delaying the first render past the 5.5 MB wasm fetch. Bundling the Python runtime into the Worker script removed that delay, and the first render now beats the wasm.

1. The `streamlit` submodule moves onto `stlite-1.62.0-2`, whose single commit awaits the initializer at the top level so the module cannot be evaluated before `readParquet` works. That top-level `await` needs `target: es2017`, so `packages/react/tsconfig.json`, the only tsconfig that typechecks submodule sources, moves up from `es6`.
2. The `changes` job's `kernel`, `react` and `cloudflare` filters gain the `streamlit` gitlink. A bump used to reach them as "nothing changed", which skipped both Cloudflare jobs; that blind spot is why the break landed on `main` green, and without closing it this pull request could not run the job it fixes either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f23eZd6gt8EdTJTYX28aF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a race condition that could cause dataframe parsing to fail before the WebAssembly module was ready.
  - Improved reliability when processing Arrow data, including in Cloudflare deployments.

- **Chores**
  - Updated build configuration to better support modern JavaScript features.
  - Improved automated build triggering when the Streamlit component changes.

- **Releases**
  - Prepared patch releases for the React, browser, desktop, sharing, and Cloudflare packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->